### PR TITLE
Add the GetCapabilities message to the D-Bus server.

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -226,6 +226,14 @@ namespace SwayNotificatonCenter {
             notiWin.close_notification (id);
         }
 
+        public string[] GetCapabilities () throws DBusError, IOError {
+            return {
+                "actions",
+                "body",
+                "persistence",
+            };
+        }
+
         public void GetServerInformation (out string name,
                                           out string vendor,
                                           out string version,


### PR DESCRIPTION
The [D-Bus notification protocol](https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html) requires `GetCapabilities` to be defined; not having it means that Firefox (at least) falls back to its own, non-native notifications instead of sending notifications to swaync.

I believe the list of capabilities matches what swaync can currently handle, based on a quick and dirty set of tests, but it's certainly possible I'm wrong. The protocol spec linked above includes a list of possible capabilities.