### PR TITLE
Fix layershell 0.5.0 not compiling

### DIFF
--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -94,11 +94,11 @@ namespace SwayNotificatonCenter {
             this.cc_daemon = cc_daemon;
             GtkLayerShell.init_for_window (this);
             // Grabs the keyboard input until closed
-            if (GtkLayerShell.get_minor_version () > 5) {
-                GtkLayerShell.set_keyboard_mode (this, GtkLayerShell.KeyboardMode.ON_DEMAND);
-            } else {
-                GtkLayerShell.set_keyboard_interactivity (this, true);
-            }
+#if HAVE_LATEST_GTK_LAYER_SHELL
+            GtkLayerShell.set_keyboard_mode (this, GtkLayerShell.KeyboardMode.ON_DEMAND);
+#else
+            GtkLayerShell.set_keyboard_interactivity (this, true);
+#endif
             GtkLayerShell.set_layer (this, GtkLayerShell.Layer.TOP);
 
             GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.TOP, true);

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,15 @@ app_deps = [
   meson.get_compiler('c').find_library('m', required : true),
 ]
 
+# Detect gtk-layer-shell version
+gtk_layer_shell = dependency(
+  'gtk-layer-shell-0',
+  fallback: ['gtk-layer-shell-0', 'gtk-layer-shell'],
+)
+if gtk_layer_shell.version() >= '0.6.0'
+    add_project_arguments('-D', 'HAVE_LATEST_GTK_LAYER_SHELL', language: 'vala')
+endif
+
 args = [
   '--target-glib=2.50',
   '--pkg=GtkLayerShell-0.1',


### PR DESCRIPTION
Fix GtkLayerShell not supporting `set_keyboard_mode` in versions below 0.6.0