### PR TITLE
Remove notification on CLOSED_BY_CLOSENOTIFICATION

### DIFF
--- a/src/notiDaemon/notiDaemon.vala
+++ b/src/notiDaemon/notiDaemon.vala
@@ -81,8 +81,9 @@ namespace SwayNotificatonCenter {
             NotiWindow.instance (dbusInit).close_all_notifications ();
         }
 
-        // Only remove the popup without removing the it from the panel
         public void CloseNotification (uint32 id) throws DBusError, IOError {
+            NotiWindow.instance (dbusInit).close_notification (id);
+            dbusInit.ccDaemon.close_notification (id);
             NotificationClosed (id, ClosedReasons.CLOSED_BY_CLOSENOTIFICATION);
         }
 


### PR DESCRIPTION
The current behavior is to ignore the `CLOSED_BY_CLOSENOTIFICATION` signal.

> Only remove the popup without removing the it from the panel

Opposing the comment, neither the popup is removed, nor is the notification removed from the panel.

Can be tested with 
```bash
# show a test notification
gdbus call --session --dest org.freedesktop.Notifications --object-path /org/freedesktop/Notifications --method org.freedesktop.Notifications.Notify my_app_name 42 audio-card "Message" "Body" "[]" "{}" 20000
# close the notification
gdbus call --session --dest org.freedesktop.Notifications --object-path /org/freedesktop/Notifications --method org.freedesktop.Notifications.CloseNotification 1 # where "1" should be replaced with the id printed by the first command
```
(via https://unix.stackexchange.com/a/75411)

The proposed changes cause the popup to be dismissed and the notification to be removed from the panel. (Again, try and error, but seems to work.)

If there is debate about this behavior, maybe a configuration option would make sense, but I found that I always prefer the proposed behavior.