### PR TITLE
Add multiple settings and other improvements

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,6 +3,6 @@
   "positionY": "top",
   "timeout": 10,
   "timeout-low": 5,
-  "keyboard_shortcuts": true,
+  "keyboard-shortcuts": true,
   "image-visibility": "always"
 }

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,10 @@
 {
   "positionX": "right",
   "positionY": "top",
+  "margin-top": 0,
+  "margin-bottom": 0,
+  "margin-right": 0,
+  "margin-left": 0,
   "timeout": 10,
   "timeout-low": 5,
   "keyboard-shortcuts": true,

--- a/src/config.json
+++ b/src/config.json
@@ -7,6 +7,7 @@
   "margin-left": 0,
   "timeout": 10,
   "timeout-low": 5,
+  "timeout-critical": 0,
   "keyboard-shortcuts": true,
   "image-visibility": "always"
 }

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -152,6 +152,11 @@ namespace SwayNotificatonCenter {
          */
         public int notification_center_width { get; set; default = 500; }
 
+        /**
+         * Notification window's width, in pixels.
+         */
+        public int notification_window_width { get; set; default = 500; }
+
         /* Methods */
 
         /**

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -107,6 +107,18 @@ namespace SwayNotificatonCenter {
             }
         }
 
+        /** The timeout for notifications with CRITICAL priority */
+        private const int _timeout_critical_def = 0;
+        private int _timeout_critical = _timeout_critical_def;
+        public int timeout_critical {
+            get {
+                return _timeout_critical;
+            }
+            set {
+                _timeout_critical = value < 1 ? _timeout_critical_def : value;
+            }
+        }
+
         /*
          * Specifies if the control center should use keyboard shortcuts
          * and block keyboard input for other applications while open

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -120,6 +120,12 @@ namespace SwayNotificatonCenter {
             default = ImageVisibility.ALWAYS;
         }
 
+        /** GtkLayerShell margins around the notification center */
+        public int margin_top { get; set; default = 0; }
+        public int margin_bottom { get; set; default = 0; }
+        public int margin_left { get; set; default = 0; }
+        public int margin_right { get; set; default = 0; }
+
         /** Whether to expand the notification center across both edges of the screen */
         public bool fit_to_screen { get; set; default = true; }
 

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -120,6 +120,20 @@ namespace SwayNotificatonCenter {
             default = ImageVisibility.ALWAYS;
         }
 
+        /** Whether to expand the notification center across both edges of the screen */
+        public bool fit_to_screen { get; set; default = true; }
+
+        /**
+         * Notification center's height, in pixels.
+         * `0` will not set a maximum height, allowing it to expand.
+         */
+        public int notification_center_height { get; set; default = 0; }
+
+        /**
+         * Notification center's width, in pixels.
+         */
+        public int notification_center_width { get; set; default = 500; }
+
         /* Methods */
 
         /**

--- a/src/controlCenter/controlCenter.ui
+++ b/src/controlCenter/controlCenter.ui
@@ -5,7 +5,6 @@
   <template class="SwayNotificatonCenterControlCenterWidget" parent="GtkApplicationWindow">
     <property name="can-focus">False</property>
     <property name="resizable">False</property>
-    <property name="default-width">500</property>
     <property name="skip-taskbar-hint">True</property>
     <property name="skip-pager-hint">True</property>
     <property name="urgency-hint">True</property>

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -200,6 +200,11 @@ namespace SwayNotificatonCenter {
                 return false;
             });
             this.box.add (new TopAction ("Do Not Disturb", dnd_button, false));
+
+            if (ConfigModel.instance.notification_center_height != 0) {
+                this.default_height = ConfigModel.instance.notification_center_height;
+            }
+            this.default_width = ConfigModel.instance.notification_center_width;
         }
 
         /** Resets the UI positions */
@@ -216,8 +221,6 @@ namespace SwayNotificatonCenter {
 #endif
             GtkLayerShell.set_layer (this, GtkLayerShell.Layer.TOP);
 
-            GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.TOP, true);
-            GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.BOTTOM, true);
             switch (ConfigModel.instance.positionX) {
                 case PositionX.LEFT:
                     GtkLayerShell.set_anchor (this,
@@ -234,7 +237,7 @@ namespace SwayNotificatonCenter {
                     GtkLayerShell.set_anchor (this,
                                               GtkLayerShell.Edge.LEFT,
                                               false);
-                    break;                    
+                    break;
                 default:
                     GtkLayerShell.set_anchor (this,
                                               GtkLayerShell.Edge.LEFT,
@@ -248,15 +251,22 @@ namespace SwayNotificatonCenter {
                 case PositionY.BOTTOM:
                     list_reverse = true;
                     list_align = Gtk.Align.END;
+                    GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.BOTTOM, true);
                     this.box.set_child_packing (
                         scrolled_window, true, true, 0, Gtk.PackType.START);
                     break;
                 case PositionY.TOP:
                     list_reverse = false;
                     list_align = Gtk.Align.START;
+                    GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.TOP, true);
                     this.box.set_child_packing (
                         scrolled_window, true, true, 0, Gtk.PackType.END);
                     break;
+            }
+
+            if (ConfigModel.instance.fit_to_screen) {
+                GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.TOP, true);
+                GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.BOTTOM, true);
             }
 
             list_box.set_valign (list_align);

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -296,17 +296,12 @@ namespace SwayNotificatonCenter {
         }
 
         private void scroll_to_start (bool reverse) {
-            var adj = viewport.vadjustment;
-            double val = adj.get_lower ();
-            list_position = 0;
+            const bool horizontal_scroll = false;
+            Gtk.ScrollType scroll_type = Gtk.ScrollType.START;
             if (reverse) {
-                val = adj.get_upper ();
-                list_position = list_reverse ?
-                                (list_box.get_children ().length () - 1) : 0;
-                if (list_position == uint.MAX) list_position = -1;
+                scroll_type = Gtk.ScrollType.END;
             }
-            adj.set_value (val);
-            navigate_list (list_position);
+            scrolled_window.scroll_child (scroll_type, horizontal_scroll);
         }
 
         public uint notification_count () {

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -221,6 +221,11 @@ namespace SwayNotificatonCenter {
 #endif
             GtkLayerShell.set_layer (this, GtkLayerShell.Layer.TOP);
 
+            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.TOP, ConfigModel.instance.margin_top);
+            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.BOTTOM, ConfigModel.instance.margin_bottom);
+            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.RIGHT, ConfigModel.instance.margin_right);
+            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.LEFT, ConfigModel.instance.margin_left);
+
             switch (ConfigModel.instance.positionX) {
                 case PositionX.LEFT:
                     GtkLayerShell.set_anchor (this,

--- a/src/notiWindow/notiWindow.ui
+++ b/src/notiWindow/notiWindow.ui
@@ -5,7 +5,6 @@
   <template class="SwayNotificatonCenterNotiWindow" parent="GtkApplicationWindow">
     <property name="can-focus">False</property>
     <property name="resizable">False</property>
-    <property name="default-width">500</property>
     <property name="type-hint">notification</property>
     <property name="skip-taskbar-hint">True</property>
     <property name="skip-pager-hint">True</property>

--- a/src/notiWindow/notiWindow.vala
+++ b/src/notiWindow/notiWindow.vala
@@ -121,6 +121,7 @@ namespace SwayNotificatonCenter {
                                                notiDaemon,
                                                ConfigModel.instance.timeout,
                                                ConfigModel.instance.timeout_low,
+                                               ConfigModel.instance.timeout_critical,
                                                remove_notification);
 
             if (list_reverse) {

--- a/src/notiWindow/notiWindow.vala
+++ b/src/notiWindow/notiWindow.vala
@@ -27,6 +27,8 @@ namespace SwayNotificatonCenter {
             GtkLayerShell.set_layer (this, GtkLayerShell.Layer.OVERLAY);
             this.set_anchor ();
             viewport.size_allocate.connect (size_alloc);
+
+            this.default_width = ConfigModel.instance.notification_window_width;
         }
 
         private void set_anchor () {

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -57,6 +57,7 @@ namespace SwayNotificatonCenter {
             this.timeout_delay = timeout;
             this.timeout_low_delay = timeout_low;
             this.timeout_cb = callback;
+            this.body.set_lines (5);
             build_noti (param, notiDaemon);
             add_noti_timeout ();
         }
@@ -65,7 +66,12 @@ namespace SwayNotificatonCenter {
             this.notiDaemon = notiDaemon;
             this.param = param;
 
+            this.body.set_line_wrap (true);
+            this.body.set_line_wrap_mode (Pango.WrapMode.WORD_CHAR);
+            this.body.set_ellipsize (Pango.EllipsizeMode.END);
+
             this.summary.set_text (param.summary ?? param.app_name);
+            this.summary.set_ellipsize (Pango.EllipsizeMode.END);
 
             default_button.clicked.connect (click_default_action);
 


### PR DESCRIPTION
Hi,

Thanks for this notification center, I've long waited for a GTK notification center with a gnome/pantheon-like interface that worked on Sway.

This PR includes many unrelated commits that I can split-up if you want.
I recommend reviewing each commit individually.

##### Commit 1

The first commit enables showing an ellipsis when a notification's summary is too long and the body is too long.
It also enables line wrapping for overly long notifications.

![image](https://user-images.githubusercontent.com/20448408/146663758-93abe027-af91-4b5e-b108-80f29601400f.png)
![image](https://user-images.githubusercontent.com/20448408/146663809-3fc2946f-8fe9-4462-8b5f-a81d4b2d8e25.png)

The behavior can be tested with `notify-send "Ellipsis test $(python -c 'print("A"*200)')" "$(python -c 'print("A"*800)')"`.

Unfortunately, the notification window is buggy when line wrapping is enabled and does not expand to the size of the content.
The bug is not present in the notification center.

Line wrapping requires the `lines` property to be set, the maximum amount of lines could be made configurable.

##### Commit 2

The second commit makes the notification center's width and height configurable.
The option `fit-to-screen` was added, it is incompatible with `notification-center-height` since gtk-layer-shell anchors override the requested height and bind to the edges.

##### Commit 3

The third commit makes the notification center's margins configurable with GtkLayerShell.

##### Commit 4

The fourth commit adds a configurable timeout for critical notifications.

##### Commit 5

The fifth commit will make the notification center smoothly scroll to the lastest notification added.
Previously, it would jump directly with no indications.
Animations can be disabled globally in GTK with the appropriate option.

##### Commit 6

The sixth commit makes the notification window's width configurable.
