### PR TITLE
Fixed not parsing pango markup

### DIFF
--- a/src/functions.vala
+++ b/src/functions.vala
@@ -104,7 +104,7 @@ namespace SwayNotificatonCenter {
             var all = info.fetch_all ();
             if (all.length > 1 && all[1].length > 0) {
                 string img = all[1];
-                // Replace "~/" with $HOME
+                // Replaces "~/" with $HOME
                 if (img.index_of ("~/", 0) == 0) {
                     img = GLib.Environment.get_home_dir () +
                           img.slice (1, img.length);

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -128,6 +128,8 @@ namespace SwayNotificatonCenter {
 
         private void set_body () {
             string text = param.body ?? "";
+
+            // Removes all image tags and adds them to an array
             string[] img_paths = {};
             if (text.length > 0) {
                 try {
@@ -151,8 +153,27 @@ namespace SwayNotificatonCenter {
                 }
             }
 
-            text = fix_markup (text);
-            this.body.set_markup (text);
+            bool success = false;
+            try {
+                Pango.AttrList ? attr = null;
+                string ? buf = null;
+                if (Pango.parse_markup (text, -1, 0, out attr, out buf, null)) {
+                    if (buf != null) {
+                        success = true;
+                        this.body.set_markup (buf);
+                        if (attr != null) {
+                            this.body.set_attributes (attr);
+                        }
+                    }
+                }
+            } catch (Error e) {
+                stderr.printf ("Could not parse Pango markup: %s\n", e.message);
+            }
+            if (!success) {
+                // Removes all tags
+                text = fix_markup (text);
+                this.body.set_markup (text);
+            }
 
             try {
                 if (img_paths.length > 0) {

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -153,23 +153,18 @@ namespace SwayNotificatonCenter {
                 }
             }
 
-            bool success = false;
             try {
                 Pango.AttrList ? attr = null;
                 string ? buf = null;
-                if (Pango.parse_markup (text, -1, 0, out attr, out buf, null)) {
-                    if (buf != null) {
-                        success = true;
-                        this.body.set_markup (buf);
-                        if (attr != null) {
-                            this.body.set_attributes (attr);
-                        }
+                Pango.parse_markup (text, -1, 0, out attr, out buf, null);
+                if (buf != null) {
+                    this.body.set_markup (buf);
+                    if (attr != null) {
+                        this.body.set_attributes (attr);
                     }
                 }
             } catch (Error e) {
                 stderr.printf ("Could not parse Pango markup: %s\n", e.message);
-            }
-            if (!success) {
                 // Removes all tags
                 text = fix_markup (text);
                 this.body.set_markup (text);

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -130,7 +130,6 @@ namespace SwayNotificatonCenter {
             string text = param.body ?? "";
 
             // Removes all image tags and adds them to an array
-            string[] img_paths = {};
             if (text.length > 0) {
                 try {
                     GLib.Regex img_exp = new Regex (
@@ -138,6 +137,7 @@ namespace SwayNotificatonCenter {
                         RegexCompileFlags.JAVASCRIPT_COMPAT);
 
                     // Get src paths from images
+                    string[] img_paths = {};
                     MatchInfo info;
                     if (img_exp.match (text, 0, out info)) {
                         img_paths += Functions.get_match_from_info (info);
@@ -148,6 +148,23 @@ namespace SwayNotificatonCenter {
 
                     // Remove all images
                     text = img_exp.replace (text, text.length, 0, "");
+
+                    // Set the image if exists and is valid
+                    if (img_paths.length > 0) {
+                        var img = img_paths[0];
+                        var file = File.new_for_path (img);
+                        if (img.length > 0 && file.query_exists ()) {
+                            const int max_width = 200;
+                            const int max_height = 100;
+                            var buf = new Gdk.Pixbuf.from_file_at_scale (
+                                file.get_path (),
+                                max_width,
+                                max_height,
+                                true);
+                            this.body_image.set_from_pixbuf (buf);
+                            this.body_image.show ();
+                        }
+                    }
                 } catch (Error e) {
                     stderr.printf (e.message);
                 }
@@ -168,26 +185,6 @@ namespace SwayNotificatonCenter {
                 // Removes all tags
                 text = fix_markup (text);
                 this.body.set_markup (text);
-            }
-
-            try {
-                if (img_paths.length > 0) {
-                    var img = img_paths[0];
-                    var file = File.new_for_path (img);
-                    if (img.length > 0 && file.query_exists ()) {
-                        const int max_width = 200;
-                        const int max_height = 100;
-                        var buf = new Gdk.Pixbuf.from_file_at_scale (
-                            file.get_path (),
-                            max_width,
-                            max_height,
-                            true);
-                        this.body_image.set_from_pixbuf (buf);
-                        this.body_image.show ();
-                    }
-                }
-            } catch (Error e) {
-                stderr.printf (e.message);
             }
         }
 


### PR DESCRIPTION
`notify-send allo "c&#39;est révolutionnaire"` results in `c&#39;est révolutionnaire` instead of `c'est révolutionnaire`.

Also applies the markup styles to the text like `<span font="16">Big</span>`