### PR TITLE
Make notification center width and height configurable

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -87,6 +87,22 @@ config file to be able to detect config errors
 	default: true ++
 	description: Hides the control center when clicking on notification action
 
+*fit-to-screen* ++
+	type: bool ++
+	default: true ++
+	description: Whether the control center should expand vertically to fill the screen
+
+*control-center-height* ++
+	type: integer ++
+	default: 500 ++
+	description: The control centers height in pixels.
+	This setting is ignored when _fit-to-screen_ it set to "true"
+
+*control-center-width* ++
+	type: integer ++
+	default: 500 ++
+	description: The control centers width in pixels
+
 *notification-visibility* ++
 	type: object ++
 	visibility object properties: ++

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -9,6 +9,8 @@
   "timeout": 10,
   "timeout-low": 5,
   "timeout-critical": 0,
+  "fit-to-screen": true,
+  "control-center-width": 500,
   "notification-window-width": 500,
   "keyboard-shortcuts": true,
   "image-visibility": "always",

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -413,6 +413,38 @@ namespace SwayNotificationCenter {
         public bool script_fail_notify { get; set; default = true; }
 #endif
 
+        /** Whether to expand the notification center across both edges of the screen */
+        public bool fit_to_screen { get; set; default = true; }
+
+        /**
+         * Notification center's height, in pixels.
+         * Set `fit_to_screen` to true to ignore the height setting.
+         */
+        private const int control_center_minimum_height = 300;
+        private int _control_center_height = control_center_minimum_height;
+        public int control_center_height {
+            get {
+                return _control_center_height;
+            }
+            set {
+                _control_center_height = value > control_center_minimum_height ? value : control_center_minimum_height;
+            }
+        }
+
+        /**
+         * Notification center's width, in pixels.
+         */
+        private const int control_center_minimum_width = 300;
+        private int _control_center_width = control_center_minimum_width;
+        public int control_center_width {
+            get {
+                return _control_center_width;
+            }
+            set {
+                _control_center_width = value > control_center_minimum_width ? value : control_center_minimum_width;
+            }
+        }
+
         /* Methods */
 
         /**

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -11,7 +11,7 @@
       "type": "string",
       "description": "Horizontal position of control center and notification window",
       "default": "right",
-      "enum": ["right", "left"]
+      "enum": ["right", "left", "center"]
     },
     "positionY": {
       "type": "string",
@@ -58,6 +58,23 @@
       "type": "integer",
       "description": "Width of the notification in pixels",
       "default": 500
+    },
+    "fit-to-screen": {
+      "type": "boolean",
+      "description": "If the control center should expand to both edges of the screen",
+      "default": true
+    },
+    "control-center-height": {
+      "type": "integer",
+      "description": "Height of the control center in pixels. Ignored when 'fit-to-screen' is set to 'true'",
+      "default": 600,
+      "minimum": 300
+    },
+    "control-center-width": {
+      "type": "integer",
+      "description": "Width of the control center in pixels",
+      "default": 500,
+      "minimum": 300
     },
     "keyboard-shortcuts": {
       "type": "boolean",

--- a/src/controlCenter/controlCenter.ui
+++ b/src/controlCenter/controlCenter.ui
@@ -5,7 +5,6 @@
   <template class="SwayNotificationCenterControlCenter" parent="GtkApplicationWindow">
     <property name="can-focus">False</property>
     <property name="resizable">False</property>
-    <property name="default-width">500</property>
     <property name="skip-taskbar-hint">True</property>
     <property name="skip-pager-hint">True</property>
     <property name="urgency-hint">True</property>

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -36,6 +36,7 @@ namespace SwayNotificationCenter {
             this.set_anchor ();
 
             viewport.size_allocate.connect (size_alloc);
+            this.map.connect (set_anchor);
 
             // Only use release for closing notifications due to Escape key
             // sometimes being passed through to unfucused application
@@ -147,39 +148,37 @@ namespace SwayNotificationCenter {
 #endif
             GtkLayerShell.set_layer (this, GtkLayerShell.Layer.TOP);
 
-            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.TOP, ConfigModel.instance.control_center_margin_top);
-            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.BOTTOM, ConfigModel.instance.control_center_margin_bottom);
-            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.RIGHT, ConfigModel.instance.control_center_margin_right);
-            GtkLayerShell.set_margin (this, GtkLayerShell.Edge.LEFT, ConfigModel.instance.control_center_margin_left);
+            GtkLayerShell.set_margin (this,
+                                      GtkLayerShell.Edge.TOP,
+                                      ConfigModel.instance.control_center_margin_top);
+            GtkLayerShell.set_margin (this,
+                                      GtkLayerShell.Edge.BOTTOM,
+                                      ConfigModel.instance.control_center_margin_bottom);
+            GtkLayerShell.set_margin (this,
+                                      GtkLayerShell.Edge.RIGHT,
+                                      ConfigModel.instance.control_center_margin_right);
+            GtkLayerShell.set_margin (this,
+                                      GtkLayerShell.Edge.LEFT,
+                                      ConfigModel.instance.control_center_margin_left);
 
-            GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.TOP, true);
-            GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.BOTTOM, true);
-            switch (ConfigModel.instance.positionX) {
-                case PositionX.LEFT:
-                    GtkLayerShell.set_anchor (this,
-                                              GtkLayerShell.Edge.RIGHT,
-                                              false);
-                    GtkLayerShell.set_anchor (this,
-                                              GtkLayerShell.Edge.LEFT,
-                                              true);
-                    break;
-                case PositionX.CENTER:
-                    GtkLayerShell.set_anchor (this,
-                                              GtkLayerShell.Edge.RIGHT,
-                                              false);
-                    GtkLayerShell.set_anchor (this,
-                                              GtkLayerShell.Edge.LEFT,
-                                              false);
-                    break;
-                default:
-                    GtkLayerShell.set_anchor (this,
-                                              GtkLayerShell.Edge.LEFT,
-                                              false);
-                    GtkLayerShell.set_anchor (this,
-                                              GtkLayerShell.Edge.RIGHT,
-                                              true);
-                    break;
-            }
+            // Anchor to north/south edges as needed
+            bool anchorTop = ConfigModel.instance.positionY == PositionY.TOP;
+            GtkLayerShell.set_anchor (this,
+                                      GtkLayerShell.Edge.TOP,
+                                      ConfigModel.instance.fit_to_screen || anchorTop);
+            GtkLayerShell.set_anchor (this,
+                                      GtkLayerShell.Edge.BOTTOM,
+                                      ConfigModel.instance.fit_to_screen || !anchorTop);
+
+            bool anchorLeft = ConfigModel.instance.positionX == PositionX.LEFT;
+            bool anchorRight = ConfigModel.instance.positionX == PositionX.RIGHT;
+            GtkLayerShell.set_anchor (this,
+                                      GtkLayerShell.Edge.RIGHT,
+                                      anchorRight);
+            GtkLayerShell.set_anchor (this,
+                                      GtkLayerShell.Edge.LEFT,
+                                      anchorLeft);
+
             switch (ConfigModel.instance.positionY) {
                 case PositionY.BOTTOM:
                     list_reverse = true;
@@ -205,6 +204,11 @@ namespace SwayNotificationCenter {
                 int val = list_reverse ? 1 : -1;
                 return a.param.time > b.param.time ? val : val * -1;
             });
+
+            // Always set the size request in all events.
+            int configuredWidth = ConfigModel.instance.control_center_width;
+            int configuredHeight = ConfigModel.instance.control_center_height;
+            this.set_size_request (configuredWidth, configuredHeight);
         }
 
         private void size_alloc () {

--- a/src/notification/notification.ui
+++ b/src/notification/notification.ui
@@ -37,7 +37,6 @@
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkOverlay" id="overlay">
-                        <property name="width-request">500</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <child>


### PR DESCRIPTION
#33's second commit.

The second commit makes the notification center's width and height configurable.
The option `fit-to-screen` was added, it is incompatible with `notification-center-height` since gtk-layer-shell anchors override the requested height and bind to the edges.