### PR TITLE
Close control center when clearing all notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ To reload the config, you'll need to run `swaync-client --reload-config`
 - `image-visibility`: `always`, `when-available` or `never`. Notification image visiblilty
 - `transition-time`: uint (Any positive number, 0 to disable). The notification animation duration
 - `notification-window-width`: uint (Any positive number). Width of the notification in pixels
+- `hide-on-clear`: bool. Hides the control center after pressing "Clear All"
 
 The main CSS style file is located in `/etc/xdg/swaync/style.css`. Copy it over to your `.config/swaync/` folder to customize without needing root access.
 

--- a/src/config.json
+++ b/src/config.json
@@ -7,5 +7,6 @@
   "notification-window-width": 500,
   "keyboard-shortcuts": true,
   "image-visibility": "always",
-  "transition-time": 200
+  "transition-time": 200,
+  "hide-on-clear": false
 }

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -149,6 +149,11 @@ namespace SwayNotificatonCenter {
          */
         public int notification_window_width { get; set; default = 500; }
 
+        /*
+         * Hides the control center after clearing all notifications
+         */
+        public bool hide_on_clear { get; set; default = false; }
+
         /* Methods */
 
         /**

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -218,6 +218,10 @@ namespace SwayNotificatonCenter {
             } catch (Error e) {
                 stderr.printf (e.message + "\n");
             }
+
+            // hide window
+            this.set_visible (false);
+            on_visibility_change ();
         }
 
         private void navigate_list (uint i) {

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -219,9 +219,9 @@ namespace SwayNotificatonCenter {
                 stderr.printf (e.message + "\n");
             }
 
-            // hide window
-            this.set_visible (false);
-            on_visibility_change ();
+            if (ConfigModel.instance.hide_on_clear) {
+                this.set_visibility (false);
+            }
         }
 
         private void navigate_list (uint i) {


### PR DESCRIPTION
After clearing all notifications we can close the control center. I can't find a reason to keep the control center open.