### PR TITLE
Added version command to swaync

### DIFF
--- a/completions/bash/swaync
+++ b/completions/bash/swaync
@@ -4,12 +4,14 @@ _swaync() {
 
     short=(
         -h
+        -v
         -s
         -c
     )
 
     long=(
         --help
+        --version
         --style
         --config
     )

--- a/completions/bash/swaync-client
+++ b/completions/bash/swaync-client
@@ -4,6 +4,7 @@ _swaync-client() {
 
     short=(
         -h
+        -v
         -R
         -rs
         -t
@@ -20,6 +21,7 @@ _swaync-client() {
 
     long=(
         --help
+        --version
         --reload-config
         --reload-css
         --toggle-panel

--- a/completions/fish/swaync-client.fish
+++ b/completions/fish/swaync-client.fish
@@ -1,5 +1,6 @@
 complete -f -c swaync-client
 complete -c swaync-client -s h -l help --description "Show help options"
+complete -c swaync-client -s v -l version --description "Prints version"
 complete -c swaync-client -s R -l reload-config --description "Reload the config file" -r
 complete -c swaync-client -s rs -l reload-css --description "Reload the css file. Location change requires restart" -r
 complete -c swaync-client -s t -l toggle-panel --description "Toggle the notificaion panel" -r

--- a/completions/fish/swaync.fish
+++ b/completions/fish/swaync.fish
@@ -1,4 +1,5 @@
 complete -f -c swaync
 complete -c swaync -s h -l help --description "Show help options"
+complete -c swaync -s v -l version --description "Prints version"
 complete -c swaync -s s -l style --description "Use a custom Stylesheet file" -r
 complete -c swaync -s c -l config --description "Use a custom config file" -r

--- a/completions/zsh/_swaync
+++ b/completions/zsh/_swaync
@@ -2,5 +2,6 @@
 
 _arguments -s \
     '(-h --help)'{-h,--help}'[Show help options]' \
+    '(-v --version)'{-v,--version}'[Prints version]' \
     '(-s --style)'{-s,--style}'[Use a custom Stylesheet file]:files:_files' \
     '(-c --config)'{-c,--config}'[Use a custom config file]:files:_files' \

--- a/completions/zsh/_swaync-client
+++ b/completions/zsh/_swaync-client
@@ -2,6 +2,7 @@
 
 _arguments -s \
     '(-h --help)'{-h,--help}'[Show help options]' \
+    '(-v --version)'{-v,--version}'[Prints version]' \
     '(-R --reload-config)'{-R,--reload-config}'[Reload the config file]' \
     '(-rs --reload-css)'{-rs,--reload-css}'[Reload the css file. Location change requires restart]' \
     '(-t --toggle-panel)'{-t,--toggle-panel}'[Toggle the notificaion panel]' \

--- a/src/client.vala
+++ b/src/client.vala
@@ -27,6 +27,7 @@ private void print_help (string[] args) {
     print (@"\t $(args[0]) <OPTION>\n");
     print (@"Help:\n");
     print (@"\t -h, \t --help \t\t Show help options\n");
+    print (@"\t -v, \t --version \t\t Prints version\n");
     print (@"Options:\n");
     print (@"\t -R, \t --reload-config \t Reload the config file\n");
     print (@"\t -rs, \t --reload-css \t\t Reload the css file. Location change requires restart\n");
@@ -65,6 +66,10 @@ public int command_line (string[] args) {
             case "--help":
             case "-h":
                 print_help (args);
+                break;
+            case "--version":
+            case "-v":
+                stdout.printf ("%s\n", Constants.version);
                 break;
             case "--reload-config":
             case "-R":

--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -1,4 +1,5 @@
 namespace SwayNotificatonCenter {
     public class Constants {
+        public const string version = @VERSION@;
     }
 }

--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -1,3 +1,4 @@
 public class Constants {
     public const string version = @VERSION@;
+    public const string versionNum = @VERSION_NUM@;
 }

--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -1,5 +1,3 @@
-namespace SwayNotificatonCenter {
-    public class Constants {
-        public const string version = @VERSION@;
-    }
+public class Constants {
+    public const string version = @VERSION@;
 }

--- a/src/main.vala
+++ b/src/main.vala
@@ -8,10 +8,6 @@ namespace SwayNotificatonCenter {
         Hdy.init ();
 
         if (args.length > 0) {
-            if ("-h" in args || "--help" in args) {
-                print_help (args);
-                return;
-            }
             for (uint i = 1; i < args.length; i++) {
                 string arg = args[i];
                 switch (arg) {
@@ -23,6 +19,12 @@ namespace SwayNotificatonCenter {
                     case "--config":
                         config_path = args[++i];
                         break;
+                    case "-v":
+                    case "--version":
+                        print ("%s\n", Constants.version);
+                        return;
+                    case "-h":
+                    case "--help":
                     default:
                         print_help (args);
                         return;
@@ -66,6 +68,7 @@ namespace SwayNotificatonCenter {
         print (@"\t $(args[0]) <OPTION>\n");
         print (@"Help:\n");
         print (@"\t -h, --help \t\t Show help options\n");
+        print (@"\t -v, --version \t\t Prints version\n");
         print (@"Options:\n");
         print (@"\t -s, --style \t\t Use a custom Stylesheet file\n");
         print (@"\t -c, --config \t\t Use a custom config file\n");

--- a/src/main.vala
+++ b/src/main.vala
@@ -21,7 +21,7 @@ namespace SwayNotificatonCenter {
                         break;
                     case "-v":
                     case "--version":
-                        print ("%s\n", Constants.version);
+                        stdout.printf ("%s\n", Constants.version);
                         return;
                     case "-h":
                     case "--help":

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,27 @@
+# Sets the version to a vala variable in Contants.vala
+version = '@0@'.format(meson.project_version())
+git = find_program('git', native: true, required: false)
+if git.found()
+  git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'])
+  git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'])
+  if git_commit.returncode() == 0 and git_branch.returncode() == 0
+    version = '@0@ (git-@1@, branch \'@2@\')'.format(
+      meson.project_version(),
+      git_commit.stdout().strip(),
+      git_branch.stdout().strip(),
+    )
+  endif
+endif
+version = 'swaync @0@'.format(version)
+message('Building version:', version)
+const_config_data = configuration_data()
+const_config_data.set_quoted('VERSION', version)
+constants = configure_file(
+  input : 'constants.vala.in',
+  output : 'constants.vala',
+  configuration : const_config_data
+)
+
 app_sources = [
   'main.vala',
   'configModel/configModel.vala',
@@ -8,8 +32,8 @@ app_sources = [
   'ccDaemon/ccDaemon.vala',
   'controlCenter/controlCenter.vala',
   'controlCenter/topAction/topAction.vala',
-  'constants.vala',
   'functions.vala',
+  constants,
 ]
 
 app_deps = [
@@ -51,7 +75,7 @@ executable('swaync',
 )
 
 executable('swaync-client',
-  ['client.vala', 'constants.vala'],
+  ['client.vala', constants],
   vala_args: args,
   dependencies: app_deps,
   install: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ version = 'swaync @0@'.format(version)
 message('Building version:', version)
 const_config_data = configuration_data()
 const_config_data.set_quoted('VERSION', version)
+const_config_data.set_quoted('VERSION_NUM', meson.project_version())
 constants = configure_file(
   input : 'constants.vala.in',
   output : 'constants.vala',

--- a/src/notiDaemon/notiDaemon.vala
+++ b/src/notiDaemon/notiDaemon.vala
@@ -182,7 +182,7 @@ namespace SwayNotificatonCenter {
         throws DBusError, IOError {
             name = "SwayNotificationCenter";
             vendor = "ErikReider";
-            version = "0.3";
+            version = Constants.versionNum;
             spec_version = "1.2";
         }
 


### PR DESCRIPTION
Output examples of running `swaync -v`, `swaync --version`, `swaync-client -v` or `swaync-client --version`:
`swaync 0.3 (git-5bf8934, branch 'print-version')` for git version
`swaync 0.3` for stable version