### PR TITLE
docs: mention css reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ To reload the config
 ./build/src/swaync-client -R
 ```
 
+To reload css after changes
+
+```zsh
+./build/src/swaync-client -rs
+```
+
 ## Control Center Shortcuts
 
 - Up/Down: Navigate notifications


### PR DESCRIPTION
ran into this when themeing SwayNotificationCenter, assumed a `-R` alone
would bounce the css settings.

easier to make mention of this right away and avoid others debugging for
a bit.

Signed-off-by: ldelossa <louis.delos@gmail.com>