### PR TITLE
waybar integration: emit an array of classses rather than a single class

### DIFF
--- a/src/client.vala
+++ b/src/client.vala
@@ -57,13 +57,15 @@ private void on_subscribe_waybar (uint count, bool dnd, bool cc_open) {
     if (count > 0) {
         tooltip = @"$(count) Notification" + (count > 1 ? "s" : "");
     }
-    print ("{\"text\": \"\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": ",state, tooltip);
+
+    string _class = @"\"$(state)\"";
     if (cc_open) {
-        print("[\"%s\", \"cc-open\"]", state);
-    } else {
-        print("\"%s\"", state);
+        _class = @"[$(_class), \"cc-open\"]";
     }
-    print("}\n");
+
+    print (
+        "{\"text\": \"\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": %s}\n",
+        state, tooltip, _class);
 }
 
 public int command_line (string[] args) {

--- a/src/client.vala
+++ b/src/client.vala
@@ -52,15 +52,18 @@ private void on_subscribe (uint count, bool dnd, bool cc_open) {
 
 private void on_subscribe_waybar (uint count, bool dnd, bool cc_open) {
     string state = (dnd ? "dnd-" : "") + (count > 0 ? "notification" : "none");
-    if (cc_open) state += " cc-open";
 
     string tooltip = "";
     if (count > 0) {
         tooltip = @"$(count) Notification" + (count > 1 ? "s" : "");
     }
-
-    print ("{\"text\": \"\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": \"%s\"}\n",
-           state, tooltip, state);
+    print ("{\"text\": \"\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": ",state, tooltip);
+    if (cc_open) {
+        print("[\"%s\", \"cc-open\"]", state);
+    } else {
+        print("\"%s\"", state);
+    }
+    print("}\n");
 }
 
 public int command_line (string[] args) {


### PR DESCRIPTION
My bad, the example output I showed in https://github.com/ErikReider/SwayNotificationCenter/issues/101 wasn't in the correct format.

Waybar doesn't like:
```"class": "foo bar"```

^ it treats this as a single class "foo bar" (which then breaks existing styles)

Instead it wants:
```"class": ["foo", "bar"]```
