### PR TITLE
Cache DND

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A simple notification daemon with a GTK gui for notifications and the control ce
 - A panel to view previous notifications
 - Show album art for notifications like Spotify
 - Do not disturb
+- Restores previous Do not disturb value after restart
 - Click notification to execute default action
 - Show alternative notification actions
 - Customization through a CSS file

--- a/src/cacher/cacher.vala
+++ b/src/cacher/cacher.vala
@@ -10,27 +10,13 @@ namespace SwayNotificationCenter {
             }
         }
 
-        private enum CacheType {
-            NOTIFICATIONS, WIDGET_STATE;
-        }
-
         private const string CACHE_FILE_STATE = "swaync-state.cache";
-        private const string CACHE_FILE_NOTIFICAIONS = "swaync-notifications.cache";
         private const FileCreateFlags FILE_FLAGS = FileCreateFlags.PRIVATE
                                                    | FileCreateFlags.REPLACE_DESTINATION;
 
-        private string get_cache_path (CacheType type) {
-            string cache_type;
-            switch (type) {
-                case CacheType.WIDGET_STATE:
-                    cache_type = CACHE_FILE_STATE;
-                    break;
-                default:
-                case CacheType.NOTIFICATIONS:
-                    cache_type = CACHE_FILE_NOTIFICAIONS;
-                    break;
-            }
-            string path = Path.build_filename (Environment.get_user_cache_dir (), cache_type);
+        private string get_cache_path () {
+            string path = Path.build_filename (Environment.get_user_cache_dir (),
+                                               CACHE_FILE_STATE);
 
             File file = File.new_for_path (path);
             if (!file.query_exists ()) {
@@ -43,14 +29,8 @@ namespace SwayNotificationCenter {
             return path;
         }
 
-        public void cache_notification (NotifyParams param) {
-            string path = get_cache_path (CacheType.NOTIFICATIONS);
-        }
-
-        public void get_notification_cache () {}
-
         public bool cache_state (StateCache state) {
-            string path = get_cache_path (CacheType.WIDGET_STATE);
+            string path = get_cache_path ();
             Json.Node json = Json.gobject_serialize (state);
             string data = Json.to_string (json, true);
 
@@ -70,7 +50,7 @@ namespace SwayNotificationCenter {
         }
 
         public StateCache get_state_cache () {
-            string path = get_cache_path (CacheType.WIDGET_STATE);
+            string path = get_cache_path ();
             StateCache s = null;
             try {
                 Json.Parser parser = new Json.Parser ();
@@ -80,12 +60,12 @@ namespace SwayNotificationCenter {
                     throw new Json.ParserError.PARSE ("Node is null!");
                 }
 
-                StateCache state = Json.gobject_deserialize (
+                StateCache model = Json.gobject_deserialize (
                     typeof (StateCache), node) as StateCache;
-                if (state == null) {
+                if (model == null) {
                     throw new Json.ParserError.UNKNOWN ("Json model is null!");
                 }
-                s = state;
+                s = model;
             } catch (Error e) {
                 stderr.printf (e.message + "\n");
             }

--- a/src/cacher/cacher.vala
+++ b/src/cacher/cacher.vala
@@ -1,0 +1,99 @@
+namespace SwayNotificationCenter {
+    public class Cacher {
+        private static Cacher _instance;
+
+        /** Get the static singleton */
+        public static unowned Cacher instance {
+            get {
+                if (_instance == null) _instance = new Cacher ();
+                return _instance;
+            }
+        }
+
+        private enum CacheType {
+            NOTIFICATIONS, WIDGET_STATE;
+        }
+
+        private const string CACHE_FILE_STATE = "swaync-state.cache";
+        private const string CACHE_FILE_NOTIFICAIONS = "swaync-notifications.cache";
+        private const FileCreateFlags FILE_FLAGS = FileCreateFlags.PRIVATE
+                                                   | FileCreateFlags.REPLACE_DESTINATION;
+
+        private string get_cache_path (CacheType type) {
+            string cache_type;
+            switch (type) {
+                case CacheType.WIDGET_STATE:
+                    cache_type = CACHE_FILE_STATE;
+                    break;
+                default:
+                case CacheType.NOTIFICATIONS:
+                    cache_type = CACHE_FILE_NOTIFICAIONS;
+                    break;
+            }
+            string path = Path.build_filename (Environment.get_user_cache_dir (), cache_type);
+
+            File file = File.new_for_path (path);
+            if (!file.query_exists ()) {
+                try {
+                    file.create (FILE_FLAGS);
+                } catch (Error e) {
+                    stderr.printf ("Error: %s\n", e.message);
+                }
+            }
+            return path;
+        }
+
+        public void cache_notification (NotifyParams param) {
+            string path = get_cache_path (CacheType.NOTIFICATIONS);
+        }
+
+        public void get_notification_cache () {}
+
+        public bool cache_state (StateCache state) {
+            string path = get_cache_path (CacheType.WIDGET_STATE);
+            Json.Node json = Json.gobject_serialize (state);
+            string data = Json.to_string (json, true);
+
+            try {
+                File file = File.new_for_path (path);
+
+                return file.replace_contents (
+                    data.data,
+                    null,
+                    false,
+                    FILE_FLAGS,
+                    null);
+            } catch (Error e) {
+                stderr.printf ("Cache state write error: %s\n", e.message);
+                return false;
+            }
+        }
+
+        public StateCache get_state_cache () {
+            string path = get_cache_path (CacheType.WIDGET_STATE);
+            StateCache s = null;
+            try {
+                Json.Parser parser = new Json.Parser ();
+                parser.load_from_file (path);
+                Json.Node ? node = parser.get_root ();
+                if (node == null) {
+                    throw new Json.ParserError.PARSE ("Node is null!");
+                }
+
+                StateCache state = Json.gobject_deserialize (
+                    typeof (StateCache), node) as StateCache;
+                if (state == null) {
+                    throw new Json.ParserError.UNKNOWN ("Json model is null!");
+                }
+                s = state;
+            } catch (Error e) {
+                stderr.printf (e.message + "\n");
+            }
+            return s ?? new StateCache ();
+        }
+    }
+
+    public class StateCache : Object {
+        public bool dnd_state { get; set; default = false; }
+    }
+}

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -15,6 +15,7 @@ namespace SwayNotificationCenter {
         private Gtk.Button clear_all_button;
 
         private SwayncDaemon swaync_daemon;
+        private NotiDaemon noti_daemon;
 
         private uint list_position = 0;
 
@@ -22,8 +23,9 @@ namespace SwayNotificationCenter {
         private bool list_reverse = false;
         private Gtk.Align list_align = Gtk.Align.START;
 
-        public ControlCenter (SwayncDaemon swaync_daemon) {
+        public ControlCenter (SwayncDaemon swaync_daemon, NotiDaemon noti_daemon) {
             this.swaync_daemon = swaync_daemon;
+            this.noti_daemon = noti_daemon;
 
             if (!GtkLayerShell.is_supported ()) {
                 stderr.printf ("GTKLAYERSHELL IS NOT SUPPORTED!\n");
@@ -121,14 +123,12 @@ namespace SwayNotificationCenter {
                                          clear_all_button,
                                          true));
 
-            dnd_button = new Gtk.Switch ();
+            dnd_button = new Gtk.Switch () {
+                state = noti_daemon.dnd,
+            };
             dnd_button.get_style_context ().add_class ("control-center-dnd");
             dnd_button.state_set.connect ((widget, state) => {
-                try {
-                    this.swaync_daemon.set_dnd (state);
-                } catch (Error e) {
-                    stderr.printf (e.message + "\n");
-                }
+                noti_daemon.dnd = state;
                 return false;
             });
             this.box.add (new TopAction ("Do Not Disturb", dnd_button, false));
@@ -240,8 +240,8 @@ namespace SwayNotificationCenter {
 
             try {
                 swaync_daemon.subscribe (notification_count (),
-                                     swaync_daemon.get_dnd (),
-                                     get_visibility ());
+                                         swaync_daemon.get_dnd (),
+                                         get_visibility ());
             } catch (Error e) {
                 stderr.printf (e.message + "\n");
             }
@@ -312,8 +312,8 @@ namespace SwayNotificationCenter {
             }
             try {
                 swaync_daemon.subscribe (notification_count (),
-                                     swaync_daemon.get_dnd (),
-                                     get_visibility ());
+                                         swaync_daemon.get_dnd (),
+                                         get_visibility ());
             } catch (Error e) {
                 stderr.printf (e.message + "\n");
             }
@@ -333,8 +333,8 @@ namespace SwayNotificationCenter {
             scroll_to_start (list_reverse);
             try {
                 swaync_daemon.subscribe (notification_count (),
-                                     swaync_daemon.get_dnd (),
-                                     get_visibility ());
+                                         swaync_daemon.get_dnd (),
+                                         get_visibility ());
             } catch (Error e) {
                 stderr.printf (e.message + "\n");
             }

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ app_sources = [
   'notification/notification.vala',
   'controlCenter/controlCenter.vala',
   'controlCenter/topAction/topAction.vala',
+  'cacher/cacher.vala',
   'functions.vala',
   constants,
 ]

--- a/src/swayncDaemon/swayncDaemon.vala
+++ b/src/swayncDaemon/swayncDaemon.vala
@@ -1,9 +1,17 @@
 namespace SwayNotificationCenter {
     [DBus (name = "org.erikreider.swaync.cc")]
     public class SwayncDaemon : Object {
+        public StateCache cache_state;
+
         public NotiDaemon noti_daemon;
 
         public SwayncDaemon () {
+            this.cache_state = Cacher.instance.get_state_cache ();
+            this.cache_state.notify.connect ((x, r) => {
+                debug ("State changed: %s\n", r.name);
+                Cacher.instance.cache_state (cache_state);
+            });
+
             // Init noti_daemon
             this.noti_daemon = new NotiDaemon (this);
             Bus.own_name (BusType.SESSION, "org.freedesktop.Notifications",
@@ -140,12 +148,12 @@ namespace SwayNotificationCenter {
 
         /** Sets the current Do Not Disturb state */
         public void set_dnd (bool state) throws DBusError, IOError {
-            noti_daemon.set_dnd (state);
+            noti_daemon.set_do_not_disturb (state);
         }
 
         /** Gets the current Do Not Disturb state */
         public bool get_dnd () throws DBusError, IOError {
-            return noti_daemon.get_dnd ();
+            return noti_daemon.get_do_not_disturb ();
         }
 
         /** Closes a specific notification with the `id` */


### PR DESCRIPTION
Restores the last DND value and the previous sessions notifications.

Todo:

- [x] Caching singleton
- [x] Cache DND

Fixes #100

Edit: Removed initial notification caching code due to complexity and of saving replaced notifications. May revisit this in the future