### PR TITLE
Do not keep transient notifications in the CC

### DIFF
--- a/src/notiDaemon/notiDaemon.vala
+++ b/src/notiDaemon/notiDaemon.vala
@@ -182,8 +182,8 @@ namespace SwayNotificationCenter {
                     noti_window.add_notification (param, this);
                 }
             }
-            // Only add notification to CC if it isn't IGNORED
-            if (state != NotificationStatusEnum.IGNORED) {
+            // Only add notification to CC if it isn't IGNORED and not transient
+            if (state != NotificationStatusEnum.IGNORED && !param.transient) {
                 control_center.add_notification (param, this);
             }
 

--- a/src/notiModel/notiModel.vala
+++ b/src/notiModel/notiModel.vala
@@ -83,6 +83,7 @@ namespace SwayNotificationCenter {
         public string desktop_entry { get; set; }
         public string category { get; set; }
         public bool resident { get; set; }
+        public bool transient { get; set; }
         public UrgencyLevels urgency { get; set; }
         /** Replaces the old notification with the same value of:
          * - x-canonical-private-synchronous
@@ -224,6 +225,13 @@ namespace SwayNotificationCenter {
                     case "resident":
                         if (hint_value.is_of_type (GLib.VariantType.BOOLEAN)) {
                             resident = hint_value.get_boolean ();
+                        }
+                        break;
+                    case "transient":
+                        if (hint_value.is_of_type (GLib.VariantType.BOOLEAN)) {
+                            transient = hint_value.get_boolean ();
+                        } else if (hint_value.is_of_type (GLib.VariantType.INT32)) {
+                            transient = hint_value.get_int32 () == 1;
                         }
                         break;
                     case "urgency":


### PR DESCRIPTION
Fixes #120.

Notifications can indicate in their hints that they should be transient.
A transient notification is not persistent, therefore, respects this hint and do not stack transient notifications in the control center.

Edited by @ErikReider:
Example notification
`notify-send.sh "Test Notification" '<b>Transient Notification</b>' -h "int:transient:0"`