### PR TITLE
Add missing build dependency and installed files in rpmbuild spec file

### DIFF
--- a/swaync.rpkg.spec
+++ b/swaync.rpkg.spec
@@ -21,7 +21,6 @@ BuildRequires: libgee-devel >= 0.20
 BuildRequires: json-glib-devel >= 1.0
 BuildRequires: libhandy-devel >= 1.4.0
 BuildRequires: systemd-devel
-BuildRequires: fish
 BuildRequires: scdoc
 %{?systemd_requires}
 

--- a/swaync.rpkg.spec
+++ b/swaync.rpkg.spec
@@ -21,6 +21,8 @@ BuildRequires: libgee-devel >= 0.20
 BuildRequires: json-glib-devel >= 1.0
 BuildRequires: libhandy-devel >= 1.4.0
 BuildRequires: systemd-devel
+BuildRequires: fish
+BuildRequires: scdoc
 %{?systemd_requires}
 
 %description
@@ -47,6 +49,7 @@ A simple notification daemon with a GTK gui for notifications and the control ce
 %{_bindir}/swaync-client
 %{_bindir}/swaync
 %license COPYING
+%{_sysconfdir}/xdg/swaync/configSchema.json
 %{_sysconfdir}/xdg/swaync/config.json
 %{_sysconfdir}/xdg/swaync/style.css
 %{_userunitdir}/swaync.service
@@ -63,6 +66,10 @@ A simple notification daemon with a GTK gui for notifications and the control ce
 %dir %{_datadir}/zsh/site-functions
 %{_datadir}/zsh/site-functions/_swaync
 %{_datadir}/zsh/site-functions/_swaync-client
+%{_datadir}/glib-2.0/schemas/org.erikreider.swaync.gschema.xml
+%{_mandir}/man1/swaync-client.1.gz
+%{_mandir}/man1/swaync.1.gz
+%{_mandir}/man5/swaync.5.gz
 
 # Changelog will be empty until you make first annotated Git tag.
 %changelog


### PR DESCRIPTION
Building the RPM package for fedora 36 using `rpkg` tool results in unsatisfied build dependencies.
Moreover, some files installed during the process by meson are missing in the list of the expected ones.
This commit solves those problems.