### PR TITLE
Issue #141: Waybar subscription missed opportunity

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ Waybar css file
 }
 ```
 
+Alternatively, the number of notifications can be shown by adding `{}` anywhere in the `format` field in the Waybar config
+
+```json
+  "custom/notification": {
+    "format": "{} {icon}",
+    ...
+  },
+```
+
 ## Screenshots
 
 ![Screenshot of desktop notification](./assets/desktop.png)

--- a/src/client.vala
+++ b/src/client.vala
@@ -87,9 +87,10 @@ private void on_subscribe_waybar (uint count, bool dnd, bool cc_open) {
         _class = "[%s, \"cc-open\"]".printf (_class);
     }
 
+    string total = "%u".printf (count);
     print (
         "{\"text\": \"%s\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": %s}\n",
-        count.to_string(), state, tooltip, _class);
+        total, state, tooltip, _class);
 }
 
 private void print_subscribe_waybar () {

--- a/src/client.vala
+++ b/src/client.vala
@@ -88,8 +88,8 @@ private void on_subscribe_waybar (uint count, bool dnd, bool cc_open) {
     }
 
     print (
-        "{\"text\": \"\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": %s}\n",
-        state, tooltip, _class);
+        "{\"text\": \"%s\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": %s}\n",
+        count.to_string(), state, tooltip, _class);
 }
 
 private void print_subscribe_waybar () {

--- a/src/client.vala
+++ b/src/client.vala
@@ -87,10 +87,9 @@ private void on_subscribe_waybar (uint count, bool dnd, bool cc_open) {
         _class = "[%s, \"cc-open\"]".printf (_class);
     }
 
-    string total = "%u".printf (count);
     print (
-        "{\"text\": \"%s\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": %s}\n",
-        total, state, tooltip, _class);
+        "{\"text\": \"%u\", \"alt\": \"%s\", \"tooltip\": \"%s\", \"class\": %s}\n",
+        count, state, tooltip, _class);
 }
 
 private void print_subscribe_waybar () {


### PR DESCRIPTION
This PR includes the number of notifications in the text field when `swaync-client` is called with waybar subscription. (Issue #141)

With this PR, the output of the command becomes like this (please, note the `text` field being non-empty now):
```
{"text": "1", "alt": "notification", "tooltip": "1 Notification", "class": "notification"}
{"text": "2", "alt": "notification", "tooltip": "2 Notifications", "class": "notification"}
{"text": "2", "alt": "notification", "tooltip": "2 Notifications", "class": ["notification", "cc-open"]}
{"text": "2", "alt": "notification", "tooltip": "2 Notifications", "class": ["notification", "cc-open"]}
{"text": "1", "alt": "notification", "tooltip": "1 Notification", "class": ["notification", "cc-open"]}
{"text": "0", "alt": "none", "tooltip": "", "class": ["none", "cc-open"]}
{"text": "0", "alt": "none", "tooltip": "", "class": ["none", "cc-open"]}
{"text": "0", "alt": "none", "tooltip": "", "class": ["none", "cc-open"]}
{"text": "0", "alt": "none", "tooltip": "", "class": "none"}
...
```

P.S.: I couldn't find tests for this feature. Are there any?

Thank you!