### PR TITLE
CI: Add Fedora builds (#144)

### DIFF
--- a/.github/workflows/fedora-build.yml
+++ b/.github/workflows/fedora-build.yml
@@ -1,0 +1,52 @@
+name: Check build for Fedora.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  package:
+    container: fedora:latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install tooling for source RPM build
+        run: |
+          dnf -y install @development-tools @rpm-development-tools
+          dnf -y install rpkg git
+          dnf -y install 'dnf-command(builddep)'
+
+      # It is necessary to checkout into sub-directory, because of some weird ownership problems cause by using containers
+      - name: Check out sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: swaync
+
+      - name: Generate spec
+        run: |
+          cd swaync
+          mkdir specs
+          rpkg spec --source  --outdir specs
+
+      - name: Install build dependencies
+        run: |
+          cd swaync
+          dnf -y builddep ./specs/swaync.rpkg.spec
+
+      - name: Local build
+        run: |
+          cd swaync
+          mkdir -p out
+          rpkg local --out `pwd`/out
+
+      - name: Store RPMs
+        uses: actions/upload-artifact@v3
+        with:
+          name: rpms
+          path: swaync/out/

--- a/.github/workflows/fedora-copr.yml
+++ b/.github/workflows/fedora-copr.yml
@@ -1,0 +1,38 @@
+name: Package for Fedora Copr repo
+
+on:
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  package:
+    container: fedora:latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install API token for copr-cli
+        env:
+          # To generate a new token: https://copr.fedorainfracloud.org/api/.
+          API_TOKEN_CONTENT: ${{ secrets.COPR_API_TOKEN }}
+        run: |
+          mkdir -p "$HOME/.config"
+          echo "$API_TOKEN_CONTENT" > "$HOME/.config/copr"
+
+      - name: Install tooling for source RPM build
+        run: |
+          dnf -y install copr-cli rpkg git
+
+      # It is necessary to checkout into sub-directory, because of some weird ownership problems cause by using containers
+      - name: Check out sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: swaync
+
+      - name: Submit the build to copr
+        run: |
+          cd swaync
+          rpkg -v copr-build -w ${{ secrets.COPR_REPO_NAME }}

--- a/swaync.rpkg.spec
+++ b/swaync.rpkg.spec
@@ -51,6 +51,7 @@ A simple notification daemon with a GTK gui for notifications and the control ce
 %{_sysconfdir}/xdg/swaync/configSchema.json
 %{_sysconfdir}/xdg/swaync/config.json
 %{_sysconfdir}/xdg/swaync/style.css
+%{_sysconfdir}/xdg/swaync/configSchema.json
 %{_userunitdir}/swaync.service
 %dir %{_datadir}/bash-completion
 %dir %{_datadir}/bash-completion/completions


### PR DESCRIPTION
Add Github actions for building SwayNotificationCenter on every push and publish it on Copr when it is released.

`fedora-build.yml` builds the package locally on every commit and PR. It is mostly to check that the build is not broken and there is not missing dependencies.

`fedora-copr.yml` is triggered when SwayNotificationCenter is released. It will start build on the [copr](https://copr.fedorainfracloud.org/). Copr will build the project for different Fedora versions and architectures (x86, arm64, etc).

To make `fedora-copr.yml` work you need to : 
1. Get an account on the [copr](https://copr.fedorainfracloud.org/)
2. Create a new project there, lets call it `SwayNotificationCenter`
3. Set repo secret COPR_REPO_NAME to `SwayNotificationCenter` (same as project name on Copr)
4. Get a token from https://copr.fedorainfracloud.org/api/ and set it in the repo's secrets as 'COPR_API_TOKEN'.

After that, copr shoud be updated when the next release is done.

I see that you don't want to use Github releases, feel free to change trigger event of `fedora-copr.yml` to 
```

on:  
  push:
    tags:
      - '*'
```