### PR TITLE
Adding instructions for installation on Fedora Silverblue and other rpm-ostree Fedora variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ dnf install SwayNotificationCenter
 Fedora Silverblue (and other rpm-ostree variants):
 The package can be downloaded from COPR after adding the COPR repo as a ostree repo, and installed as a overlayed package:
 ```zsh
-sudo ostree remote add SwayNotificationCenter https://download.copr.fedorainfracloud.org/results/erikreider/SwayNotificationCenter/fedora-$releasever-$basearch/
+ostree remote add SwayNotificationCenter https://download.copr.fedorainfracloud.org/results/erikreider/SwayNotificationCenter/fedora-$releasever-$basearch/
 rpm-ostree install SwayNotificationCenter
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ dnf install SwayNotificationCenter
 ```
 
 Fedora Silverblue (and other rpm-ostree variants):
-The package can be downloaded from COPR after manually adding the repo file, and installed as a overlayed package:
+The package can be downloaded from COPR after adding the COPR repo as a ostree repo, and installed as a overlayed package:
 ```zsh
-wget -O /etc/yum.repos.d/erikreider-SwayNotificationCenter.repo https://copr.fedorainfracloud.org/coprs/erikreider/SwayNotificationCenter/repo/fedora-rawhide/erikreider-SwayNotificationCenter-fedora-rawhide.repo
+sudo ostree remote add SwayNotificationCenter https://download.copr.fedorainfracloud.org/results/erikreider/SwayNotificationCenter/fedora-$releasever-$basearch/
 rpm-ostree install SwayNotificationCenter
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ dnf copr enable erikreider/SwayNotificationCenter
 dnf install SwayNotificationCenter
 ```
 
+Fedora Silverblue (and other rpm-ostree variants):
+The package can be downloaded from COPR after manually adding the repo file, and installed as a overlayed package:
+```zsh
+wget -O /etc/yum.repos.d/erikreider-SwayNotificationCenter.repo https://copr.fedorainfracloud.org/coprs/erikreider/SwayNotificationCenter/repo/fedora-rawhide/erikreider-SwayNotificationCenter-fedora-rawhide.repo
+rpm-ostree install SwayNotificationCenter
+```
+
 Gentoo:
 An **unofficial** ebuild is available in [GURU](https://github.com/gentoo/guru)
 


### PR DESCRIPTION
Inmutable Fedora systems cannot add COPR repos like the normal Workstation edition as they don't use DNF outside of containers. This pull request addresses this and adds the required instructions for those who may not know.

I'm not exactly sure if repo files for older Fedora versions are taken out once they go EOL, so I just chose to go with the Rawhide repo file since it's exactly the same as the other ones and probably will stay there forever. During the installation, the package corresponding to your Fedora version will be chosen so there should be no problems.