### PR TITLE
Add client flags to turn dnd on/off

### DIFF
--- a/completions/bash/swaync-client
+++ b/completions/bash/swaync-client
@@ -12,6 +12,8 @@ _swaync-client() {
         -cp
         -d
         -D
+        -dn
+        -df
         -c
         -C
         -sw
@@ -29,6 +31,8 @@ _swaync-client() {
         --close-panel
         --toggle-dnd
         --get-dnd
+        --dnd-on
+        --dnd-off
         --count
         --hide-latest
         --close-latest

--- a/completions/fish/swaync-client.fish
+++ b/completions/fish/swaync-client.fish
@@ -8,6 +8,8 @@ complete -c swaync-client -s op -l open-panel --description "Opens the notificai
 complete -c swaync-client -s cp -l close-panel --description "Closes the notificaion panel" -r
 complete -c swaync-client -s d -l toggle-dnd --description "Toggle and print the current dnd state" -r
 complete -c swaync-client -s D -l get-dnd --description "Print the current dnd state" -r
+complete -c swaync-client -s dn -l dnd-on --description "Turn dnd on and print the new dnd state" -r
+complete -c swaync-client -s df -l dnd-off --description "Turn dnd off and print the new dnd state" -r
 complete -c swaync-client -s c -l count --description "Print the current notificaion count" -r
 complete -c swaync-client      -l hide-latest --description "Hides latest notification. Still shown in Control Center" -r
 complete -c swaync-client      -l close-latest --description "Closes latest notification" -r

--- a/completions/zsh/_swaync-client
+++ b/completions/zsh/_swaync-client
@@ -10,6 +10,8 @@ _arguments -s \
     '(-cp --close-panel)'{-cp,--close-panel}'[Closes the notificaion panel]' \
     '(-d --toggle-dnd)'{-d,--toggle-dnd}'[Toggle and print the current dnd state]' \
     '(-D --get-dnd)'{-D,--get-dnd}'[Print the current dnd state]' \
+    '(-dn --dnd-on)'{-dn,--dnd-on}'[Turn dnd on and print the new dnd state]' \
+    '(-df --dnd-off)'{-df,--dnd-off}'[Turn dnd off and print the new dnd state]' \
     '(-c --count)'{-c,--count}'[Print the current notificaion count]' \
     '(--hide-latest)'--hide-latest'[Closes all notifications]' \
     '(--close-latest)'--close-latest'[Hides latest notification. Still shown in Control Center]' \

--- a/man/swaync-client.1.scd
+++ b/man/swaync-client.1.scd
@@ -37,6 +37,12 @@ swaync-client - Client executable
 *-D, --get-dnd*
 	Print the current dnd state
 
+*-dn, --dnd-on*
+	Turn dnd on and print the new dnd state
+
+*-df, --dnd-off*
+	Turn dnd off and print the new dnd state
+
 *-c, --count*
 	Print the current notificaion count
 

--- a/src/client.vala
+++ b/src/client.vala
@@ -19,6 +19,8 @@ interface CcDaemon : Object {
 
     public abstract bool get_dnd () throws DBusError, IOError;
 
+    public abstract void set_dnd (bool state) throws DBusError, IOError;
+
     public abstract bool get_visibility () throws DBusError, IOError;
 
     public abstract void toggle_visibility () throws DBusError, IOError;
@@ -49,6 +51,8 @@ private void print_help (string[] args) {
     print ("\t -cp, \t --close-panel \t\t Closes the notificaion panel\n");
     print ("\t -d, \t --toggle-dnd \t\t Toggle and print the current dnd state\n");
     print ("\t -D, \t --get-dnd \t\t Print the current dnd state\n");
+    print ("\t -dn, \t --dnd-on \t\t Turn dnd on and print the new dnd state\n");
+    print ("\t -df, \t --dnd-off \t\t Turn dnd off and print the new dnd state\n");
     print ("\t -c, \t --count \t\t Print the current notificaion count\n");
     print ("\t     \t --hide-latest \t\t Hides latest notification. Still shown in Control Center\n");
     print ("\t     \t --close-latest \t Closes latest notification\n");
@@ -159,6 +163,16 @@ public int command_line (string[] args) {
                 break;
             case "--get-dnd":
             case "-D":
+                print (cc_daemon.get_dnd ().to_string ());
+                break;
+            case "--dnd-on":
+            case "-dn":
+                cc_daemon.set_dnd (true);
+                print (cc_daemon.get_dnd ().to_string ());
+                break;
+            case "--dnd-off":
+            case "-df":
+                cc_daemon.set_dnd (false);
                 print (cc_daemon.get_dnd ().to_string ());
                 break;
             case "--subscribe":


### PR DESCRIPTION
Hello 👋🏻 

This is a QoL PR I offer, for which I'll be the first client. Unless I missed something, setting dnd state to on or off currently requires getting the current dnd state, and toggling if necessary. With this MR, it'll be doable in a single call to the client. Less bash scripts everywhere can only be a good thing for the world. 😛   

Fair warning:
* This is my first time poking in this codebase. I might have missed things. Feel free to tell me if anything needs tweaking.
* Up until today, I'd never even heard of vala. The edit is small and simple, and the code seems pretty straightforward, but reviewers should assume it's been written by a newbie, I won't take it personally. 😄

Thanks !