### PR TITLE
feat: transient notification visibility

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -110,7 +110,7 @@ config file to be able to detect config errors
 			type: string ++
 			optional: false ++
 			default: enabled ++
-			values: ignored, muted, enabled ++
+			values: ignored, muted, transient, enabled ++
 			description: The notification visibility state. ++
 		*app-name*++
 			type: string ++

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -137,7 +137,8 @@ namespace SwayNotificationCenter {
     public enum NotificationStatusEnum {
         ENABLED,
         MUTED,
-        IGNORED;
+        IGNORED,
+        TRANSIENT;
 
         public string to_string () {
             switch (this) {
@@ -147,6 +148,8 @@ namespace SwayNotificationCenter {
                     return "muted";
                 case IGNORED:
                     return "ignored";
+                case TRANSIENT:
+                    return "transient";
             }
         }
 
@@ -158,6 +161,8 @@ namespace SwayNotificationCenter {
                     return MUTED;
                 case "ignored":
                     return IGNORED;
+                case "transient":
+                    return TRANSIENT;
             }
         }
     }

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -186,7 +186,7 @@
               "type": "string",
               "description": "The notification visibility state.",
               "default": "enabled",
-              "enum": ["ignored", "muted", "enabled"]
+              "enum": ["ignored", "muted", "enabled", "transient"]
             },
             "app-name": {
               "type": "string",

--- a/src/notiDaemon/notiDaemon.vala
+++ b/src/notiDaemon/notiDaemon.vala
@@ -172,16 +172,18 @@ namespace SwayNotificationCenter {
                 synchronous_ids.set (param.synchronous, id);
             }
 
-            // Only show popup notification if it is ENABLED
-            if (state == NotificationStatusEnum.ENABLED
+            // Only show popup notification if it is ENABLED or TRANSIENT
+            if ((state == NotificationStatusEnum.ENABLED || state == NotificationStatusEnum.TRANSIENT)
                 && !control_center.get_visibility ()) {
                 if (param.urgency == UrgencyLevels.CRITICAL ||
                     (!dnd && param.urgency != UrgencyLevels.CRITICAL)) {
                     NotificationWindow.instance.add_notification (param, this);
                 }
             }
-            // Only add notification to CC if it isn't IGNORED and not transient
-            if (state != NotificationStatusEnum.IGNORED && !param.transient) {
+            // Only add notification to CC if it isn't IGNORED and not transient/TRANSIENT
+            if (state != NotificationStatusEnum.IGNORED
+                  && state != NotificationStatusEnum.TRANSIENT
+                  && !param.transient) {
                 control_center.add_notification (param, this);
             }
 


### PR DESCRIPTION
Hi and thanks for this great tool !

This PR adds a new **configurable** visibility state called transient. It allows the user to set the transient state of a notification in order for it to show, but not to be added to the CC.
This is useful, for instance, for certain music apps that show a notification on track changes. We might want to see them, but we don't necessarily want them in the CC.

Thanks !