### PR TITLE
Add option to configure layer for control center window

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -21,6 +21,12 @@ config file to be able to detect config errors
 	values: top, bottom ++
 	description: Vertical position of control center and notification window
 
+*layer* ++
+	type: string ++
+	default: top ++
+	values: background, bottom, top, overlay ++
+	description: Layer of control center window relative to normal windows. background is below all windows, overlay is above all windows.
+
 *control-center-margin-top* ++
 	type: integer ++
 	default: 0 ++

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -2,6 +2,7 @@
   "$schema": @JSONPATH@,
   "positionX": "right",
   "positionY": "top",
+  "layer": "top",
   "control-center-margin-top": 0,
   "control-center-margin-bottom": 0,
   "control-center-margin-right": 0,

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -42,6 +42,25 @@ namespace SwayNotificationCenter {
         }
     }
 
+    public enum Layer {
+        BACKGROUND, BOTTOM, TOP, OVERLAY;
+
+        public string parse () {
+            switch (this) {
+                default:
+                    return "top";
+                case BACKGROUND:
+                    return "background";
+                case BOTTOM:
+                    return "bottom";
+                case TOP:
+                    return "top";
+                case OVERLAY:
+                    return "overlay";
+            }
+        }
+    }
+
     public class Category : Object {
         public string ? sound { get; set; default = null; }
         public string ? icon { get; set; default = null; }
@@ -282,6 +301,11 @@ namespace SwayNotificationCenter {
         /** The notifications and controlcenters vertical alignment */
         public PositionY positionY { // vala-lint=naming-convention
             get; set; default = PositionY.TOP;
+        }
+
+        /** Layer of control center */
+        public Layer layer {
+            get; set; default = Layer.TOP;
         }
 
         /** The timeout for notifications with NORMAL priority */

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -14,6 +14,12 @@
       "default": "right",
       "enum": ["right", "left", "center"]
     },
+    "layer": {
+      "type": "string",
+      "description": "Layer of control center window",
+      "default": "top",
+      "enum": ["background", "bottom", "top", "overlay"]
+    },
     "positionY": {
       "type": "string",
       "description": "Vertical position of control center and notification window",

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -212,7 +212,24 @@ namespace SwayNotificationCenter {
 #else
             GtkLayerShell.set_keyboard_interactivity (this, keyboard_shortcuts);
 #endif
-            GtkLayerShell.set_layer (this, GtkLayerShell.Layer.TOP);
+
+            // Set layer
+            GtkLayerShell.Layer layer = GtkLayerShell.Layer.TOP;
+            switch (ConfigModel.instance.layer) {
+                case Layer.BACKGROUND:
+                    layer = GtkLayerShell.Layer.BACKGROUND;
+                    break;
+                case Layer.BOTTOM:
+                    layer = GtkLayerShell.Layer.BOTTOM;
+                    break;
+                case Layer.TOP:
+                    layer = GtkLayerShell.Layer.TOP;
+                    break;
+                case Layer.OVERLAY:
+                    layer = GtkLayerShell.Layer.OVERLAY;
+                    break;
+            }
+            GtkLayerShell.set_layer (this, layer);
 
             // Set the box margins
             box.set_margin_top (ConfigModel.instance.control_center_margin_top);


### PR DESCRIPTION
Hi!

This adds a config option to configure the layer_shell layer, ie the rules for above/below which windows the control center will appear. This is mostly for overlay so it can appear above fullscreen windows, I doubt background and bottom are useful really, but they're there, so why not expose them :shrug: 