### PR TITLE
Add COPYING and README to pkgbuild install

### DIFF
--- a/build-scripts/PKGBUILD
+++ b/build-scripts/PKGBUILD
@@ -24,5 +24,7 @@ build() {
 }
 
 package() {
-    DESTDIR="$pkgdir" meson install -C build
+    DESTDIR="$pkgdir/" ninja -C build install
+    install -Dm644 "$_pkgfoldername-$pkgver/COPYING" -t "$pkgdir/usr/share/licenses/$pkgname"
+    install -Dm644 "$_pkgfoldername-$pkgver/README.md" -t "$pkgdir/usr/share/doc/$pkgname"
 }

--- a/build-scripts/PKGBUILD-git
+++ b/build-scripts/PKGBUILD-git
@@ -38,5 +38,7 @@ build() {
 }
 
 package() {
-    DESTDIR="$pkgdir" meson install -C build
+    DESTDIR="$pkgdir/" ninja -C build install
+    install -Dm644 "$_pkgfoldername-$pkgver/COPYING" -t "$pkgdir/usr/share/licenses/$pkgname"
+    install -Dm644 "$_pkgfoldername-$pkgver/README.md" -t "$pkgdir/usr/share/doc/$pkgname"
 }


### PR DESCRIPTION
Per #144 to prep for trying to get the package in \[community\]

COPYING is standard naming for license files under GNU, so no need to change it (counter to my comment on #144)