### PR TITLE
Add ControlCenter positioning config option

### DIFF
--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -1,30 +1,10 @@
 namespace SwayNotificationCenter {
     public enum PositionX {
-        RIGHT, LEFT, CENTER;
-
-        public string parse () {
-            switch (this) {
-                default:
-                    return "right";
-                case LEFT:
-                    return "left";
-                case CENTER:
-                    return "center";
-            }
-        }
+        RIGHT, LEFT, CENTER, NONE;
     }
 
     public enum PositionY {
-        TOP, BOTTOM;
-
-        public string parse () {
-            switch (this) {
-                default:
-                    return "top";
-                case BOTTOM:
-                    return "bottom";
-            }
-        }
+        TOP, BOTTOM, NONE;
     }
 
     public enum ImageVisibility {
@@ -431,6 +411,15 @@ namespace SwayNotificationCenter {
 
         /** Hides the control center when clicking on notification action */
         public bool hide_on_action { get; set; default = true; }
+
+        /** The controlcenters horizontal alignment. Supersedes `positionX` if not `NONE` */
+        public PositionX control_center_positionX { // vala-lint=naming-convention
+            get; set; default = PositionX.NONE;
+        }
+        /** The controlcenters vertical alignment. Supersedes `positionY` if not `NONE` */
+        public PositionY control_center_positionY { // vala-lint=naming-convention
+            get; set; default = PositionY.NONE;
+        }
 
         /** GtkLayerShell margins around the notification center */
         private int control_center_margin_top_ = 0;

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -32,6 +32,18 @@
       "default": "top",
       "enum": ["top", "bottom"]
     },
+    "control-center-positionX": {
+      "type": "string",
+      "description": "Optional: Horizontal position of the control center. Supersedes positionX if not set to `none`",
+      "default": "none",
+      "enum": ["right", "left", "center", "none"]
+    },
+    "control-center-positionY": {
+      "type": "string",
+      "description": "Optional: Vertical position of the control center. Supersedes positionY if not set to `none`",
+      "default": "none",
+      "enum": ["top", "bottom", "none"]
+    },
     "control-center-margin-top": {
       "type": "integer",
       "description": "The margin (in pixels) at the top of the notification center. 0 to disable",

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -254,19 +254,25 @@ namespace SwayNotificationCenter {
 
             // Anchor box to north/south edges as needed
             Gtk.Align align_x = Gtk.Align.END;
-            switch (ConfigModel.instance.positionX) {
+            PositionX pos_x = ConfigModel.instance.control_center_positionX;
+            if (pos_x == PositionX.NONE) pos_x = ConfigModel.instance.positionX;
+            switch (pos_x) {
                 case PositionX.LEFT:
                     align_x = Gtk.Align.START;
                     break;
                 case PositionX.CENTER:
                     align_x = Gtk.Align.CENTER;
                     break;
+                default:
                 case PositionX.RIGHT:
                     align_x = Gtk.Align.END;
                     break;
             }
             Gtk.Align align_y = Gtk.Align.START;
-            switch (ConfigModel.instance.positionY) {
+            PositionY pos_y = ConfigModel.instance.control_center_positionY;
+            if (pos_y == PositionY.NONE) pos_y = ConfigModel.instance.positionY;
+            switch (pos_y) {
+                default:
                 case PositionY.TOP:
                     align_y = Gtk.Align.START;
                     // Set cc widget position


### PR DESCRIPTION
Fixes: #180 

Allows for separate Control Center and Notification Window positioning.

If the new config options aren't used, the Notification Window position is used for the Control Center