### PR TITLE
Add Notification Action to copy body security codes to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Post your setup here: [Config flex 💪](https://github.com/ErikReider/SwayNotif
 - Restores previous Do not disturb value after restart
 - Click notification to execute default action
 - Show alternative notification actions
+- Copy detected 2FA codes to clipboard
 - Customization through a CSS file
 - Trackpad/mouse gesture to close notification
 - The same features as any other basic notification daemon

--- a/src/functions.vala
+++ b/src/functions.vala
@@ -275,5 +275,16 @@ namespace SwayNotificationCenter {
                 surface,
                 (double) buffer_width / 2 / scale - width / 2, 0);
         }
+
+        public delegate bool FilterFunc (char character);
+
+        public static string filter_string (string body, FilterFunc func) {
+            string result = "";
+            foreach (char char in (char[]) body.data) {
+                if (!func (char)) continue;
+                result += char.to_string ();
+            }
+            return result;
+        }
     }
 }

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -105,7 +105,8 @@ namespace SwayNotificationCenter {
 
         construct {
             try {
-                code_regex = new Regex ("((\\D|^)(123 456)(\\D|$))|(\\D|^)\\d{4,7}(\\D|$)");
+                code_regex = new Regex ("(?<= |^)(\\d{3}(-| )\\d{3}|\\d{4,7})(?= |$|\\.|,)",
+                                        RegexCompileFlags.MULTILINE);
                 string joined_tags = string.joinv ("|", TAGS);
                 tag_regex = new Regex ("&lt;(/?(?:%s))&gt;".printf (joined_tags));
                 string unescaped = string.joinv ("|", UNESCAPE_CHARS);
@@ -296,7 +297,7 @@ namespace SwayNotificationCenter {
             if (body.length == 0) return null;
 
             MatchInfo info;
-            var result = code_regex.match_all (body, RegexMatchFlags.NOTEMPTY, out info);
+            var result = code_regex.match (body, RegexMatchFlags.NOTEMPTY, out info);
             string ? match = info.fetch (0);
             if (!result || match == null) return null;
 

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -23,7 +23,7 @@ namespace SwayNotificationCenter {
         [GtkChild]
         unowned Gtk.Button close_button;
 
-        private Gtk.ButtonBox alt_actions_box;
+        private Gtk.ButtonBox alt_actions_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
 
         [GtkChild]
         unowned Gtk.Label summary;
@@ -310,9 +310,16 @@ namespace SwayNotificationCenter {
         }
 
         public void click_alt_action (uint index) {
-            if (param.actions.length == 0 || index >= param.actions.length) {
+            List<weak Gtk.Widget>? children = alt_actions_box.get_children ();
+            uint length = children.length ();
+            if (length == 0 || index >= length) return;
+
+            unowned Gtk.Widget button = children.nth_data (index);
+            if (button is Gtk.Button) {
+                ((Gtk.Button) button).clicked ();
                 return;
             }
+            // Backup if the above fails
             action_clicked (param.actions.index (index));
         }
 
@@ -354,7 +361,6 @@ namespace SwayNotificationCenter {
             if (param.actions.length > 0 || code != null) {
                 var viewport = new Gtk.Viewport (null, null);
                 var scroll = new Gtk.ScrolledWindow (null, null);
-                alt_actions_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
                 alt_actions_box.set_homogeneous (true);
                 alt_actions_box.set_layout (Gtk.ButtonBoxStyle.EXPAND);
 

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -290,16 +290,15 @@ namespace SwayNotificationCenter {
             }
         }
 
-        /// Returns the first code found, else null
+        /** Returns the first code found, else null */
         private string ? parse_body_codes () {
             string body = this.body.get_text ().strip ();
+            if (body.length == 0) return null;
 
             MatchInfo info;
             var result = code_regex.match_all (body, RegexMatchFlags.NOTEMPTY, out info);
-            if (!result) return null;
-
             string ? match = info.fetch (0);
-            if (match == null) return null;
+            if (!result || match == null) return null;
 
             return Functions.filter_string (
                 match.strip (), (c) => c.isdigit () || c.isspace ()).strip ();
@@ -360,8 +359,8 @@ namespace SwayNotificationCenter {
 
                 // Add "Copy code" Action if available and copy it to clipboard when clicked
                 if (code != null && code.length > 0) {
-                    string name = "COPY \"%s\"".printf (code);
-                    var action_button = new Gtk.Button.with_label (name);
+                    string action_name = "COPY \"%s\"".printf (code);
+                    var action_button = new Gtk.Button.with_label (action_name);
                     action_button.clicked.connect (() => {
                         // Copy to clipboard
                         get_clipboard (Gdk.SELECTION_CLIPBOARD).set_text (code, -1);


### PR DESCRIPTION
Fixes: #215 

Adds a Notification action to copy the first detected 2fa code in the body to the primary clipboard.

Currently works with these formats: `1234`, `12345`, `123456`, `123 456`, `123-456`, `1234567`

![image](https://user-images.githubusercontent.com/35975961/219959472-b497df58-04ba-49bb-9b8c-b0cf8b91e75b.png)
