### PR TITLE
Use rounding to prevent incorrect backlight percentage calculation

### DIFF
--- a/src/controlCenter/widgets/backlight/backlightUtil.vala
+++ b/src/controlCenter/widgets/backlight/backlightUtil.vala
@@ -116,11 +116,11 @@ namespace SwayNotificationCenter.Widgets {
         }
 
         private int calc_percent (int val) {
-            return val * 100 / max;
+            return (int) Math.round(val * 100.0 / max);
         }
 
         private int calc_actual (float val) {
-            return (int) val * max / 100;
+            return (int) Math.round(val * max / 100);
         }
 
         public int get_max_value () {

--- a/src/controlCenter/widgets/backlight/backlightUtil.vala
+++ b/src/controlCenter/widgets/backlight/backlightUtil.vala
@@ -116,11 +116,11 @@ namespace SwayNotificationCenter.Widgets {
         }
 
         private int calc_percent (int val) {
-            return (int) Math.round(val * 100.0 / max);
+            return (int) Math.round (val * 100.0 / max);
         }
 
         private int calc_actual (float val) {
-            return (int) Math.round(val * max / 100);
+            return (int) Math.round (val * max / 100);
         }
 
         public int get_max_value () {


### PR DESCRIPTION
Suppose the brightness of screen is 15%, correspondingly the value of `/sys/class/backlight/amdgpu_bl0/brightness` is 38, and `max_brightness` is 255, 38/255 = 0.149, but the output of the calc_percent function is 14, causing the screen brightness will be decreased by 1% when open panel every time.