### PR TITLE
Add a tip with gtk_debug env var in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ See `swaync(5)` man page for more information
 
 To reload the config, you'll need to run `swaync-client --reload-config`
 
-The main CSS style file is located in `/etc/xdg/swaync/style.css`. Copy it over to your `~/.config/swaync/` folder to customize without needing root access.
+The main CSS style file is located in `/etc/xdg/swaync/style.css`. Copy it over to your `~/.config/swaync/` folder to customize without needing root access. **Tip**: running swaync like this `GTK_DEBUG=interactive swaync` will open a inspector window that'll allow you to see all of the CSS classes + other information.
 
 ## Notification Inhibition
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,11 @@ See `swaync(5)` man page for more information
 
 To reload the config, you'll need to run `swaync-client --reload-config`
 
-The main CSS style file is located in `/etc/xdg/swaync/style.css`. Copy it over to your `~/.config/swaync/` folder to customize without needing root access. **Tip**: running swaync like this `GTK_DEBUG=interactive swaync` will open a inspector window that'll allow you to see all of the CSS classes + other information.
+The main CSS style file is located in `/etc/xdg/swaync/style.css`. Copy it over 
+to your `~/.config/swaync/` folder to customize without needing root access. 
+
+**Tip**: running swaync with `GTK_DEBUG=interactive swaync` will open a inspector 
+window that'll allow you to see all of the CSS classes + other information.
 
 ## Notification Inhibition
 


### PR DESCRIPTION
I know that info can be dug up in the internet, but it also doesn't take much space in the readme, so why not leave it there. Would have helped me if it was there.