### PR TITLE
Added ability to choose which output to use

### DIFF
--- a/src/config.json.in
+++ b/src/config.json.in
@@ -4,6 +4,7 @@
   "positionY": "top",
   "layer": "top",
   "layer-shell": true,
+  "output": "auto",
   "cssPriority": "application",
   "control-center-margin-top": 0,
   "control-center-margin-bottom": 0,

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -310,11 +310,14 @@ namespace SwayNotificationCenter {
 
         /** Reloads the config and calls `ModifyNode` before deserializing */
         public static void reload_config (ModifyNode modify_cb = () => {}) {
+            // Re-check if config file path still exists
+            string path = Functions.get_config_path (_path);
+
             ConfigModel m = null;
             try {
-                if (_path.length == 0) return;
+                if (path.strip ().length == 0) return;
                 Json.Parser parser = new Json.Parser ();
-                parser.load_from_file (_path);
+                parser.load_from_file (path);
                 Json.Node ? node = parser.get_root ();
                 if (node == null) {
                     throw new Json.ParserError.PARSE ("Node is null!");
@@ -332,6 +335,7 @@ namespace SwayNotificationCenter {
                 stderr.printf (e.message + "\n");
             }
             _instance = m ?? new ConfigModel ();
+            _path = path;
             debug (_instance.to_string ());
         }
 
@@ -355,6 +359,12 @@ namespace SwayNotificationCenter {
          * Wether or not the windows should be opened as layer-shell surfaces
          */
         public bool layer_shell { get; set; default = true; }
+
+        /**
+         * The output to display the layer surfaces on.
+         * "auto" for automatic selection
+         */
+        public string output { get; set; default = "auto"; }
 
         /** The CSS loading priority */
         public CssPriority cssPriority { // vala-lint=naming-convention

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -25,6 +25,11 @@
       "description": "Wether or not the windows should be opened as layer-shell surfaces. Note: Requires swaync restart to apply",
       "default": true
     },
+    "output": {
+      "type": "string",
+      "description": "The output to display the layer surfaces on. \"auto\" for automatic selection",
+      "default": "auto"
+    },
     "cssPriority": {
       "type": "string",
       "description": "Which GTK priority to use when loading the default and user CSS files. Pick \"user\" to override XDG_CONFIG_HOME/gtk-3.0/gtk.css",

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -29,6 +29,8 @@ namespace SwayNotificationCenter {
         private bool list_reverse = false;
         private Gtk.Align list_align = Gtk.Align.START;
 
+        private unowned Gdk.Monitor? current_monitor;
+
         private Array<Widgets.BaseWidget> widgets = new Array<Widgets.BaseWidget> ();
         private const string[] DEFAULT_WIDGETS = { "title", "dnd", "notifications" };
 
@@ -62,6 +64,7 @@ namespace SwayNotificationCenter {
                 ulong id = 0;
                 id = notify["has-toplevel-focus"].connect (() => {
                     disconnect (id);
+
                     unowned Gdk.Monitor monitor = null;
                     unowned Gdk.Window ? win = get_window ();
                     if (win != null) {
@@ -258,6 +261,14 @@ namespace SwayNotificationCenter {
         /** Resets the UI positions */
         private void set_anchor () {
             if (swaync_daemon.use_layer_shell) {
+                // Set current monitor to display on
+                unowned Gdk.Monitor? mon
+                    = Functions.get_monitor_from_name (ConfigModel.instance.output);
+                if (mon != current_monitor) {
+                    GtkLayerShell.set_monitor (this, mon);
+                    current_monitor = mon;
+                }
+
                 // Grabs the keyboard input until closed
                 bool keyboard_shortcuts = ConfigModel.instance.keyboard_shortcuts;
 #if HAVE_LATEST_GTK_LAYER_SHELL

--- a/src/functions.vala
+++ b/src/functions.vala
@@ -286,5 +286,26 @@ namespace SwayNotificationCenter {
             }
             return result;
         }
+
+        /**
+         * Gets the Gdk.Monitor from the output_name. "auto" returns null
+         */
+        public static unowned Gdk.Monitor? get_monitor_from_name (owned string output_name) {
+            output_name = output_name.strip ().down();
+            if (output_name.length < 1 || output_name == "auto") return null;
+
+            unowned Gdk.Screen screen = Gdk.Screen.get_default ();
+            unowned Gdk.Display display = Gdk.Display.get_default ();
+            int num_monitors = display.get_n_monitors ();
+            for (int num = 0; num < num_monitors; num++) {
+                string? plug = screen.get_monitor_plug_name (num);
+                if (plug != null && plug.strip ().down() == output_name) {
+                    unowned Gdk.Monitor monitor = display.get_monitor (num);
+                    if (monitor != null) return monitor;
+                }
+            }
+            critical ("Monitor \"%s\" not found...", output_name);
+            return null;
+        }
     }
 }

--- a/src/functions.vala
+++ b/src/functions.vala
@@ -291,7 +291,7 @@ namespace SwayNotificationCenter {
          * Gets the Gdk.Monitor from the output_name. "auto" returns null
          */
         public static unowned Gdk.Monitor? get_monitor_from_name (owned string output_name) {
-            output_name = output_name.strip ().down();
+            output_name = output_name.strip ().down ();
             if (output_name.length < 1 || output_name == "auto") return null;
 
             unowned Gdk.Screen screen = Gdk.Screen.get_default ();
@@ -299,7 +299,7 @@ namespace SwayNotificationCenter {
             int num_monitors = display.get_n_monitors ();
             for (int num = 0; num < num_monitors; num++) {
                 string? plug = screen.get_monitor_plug_name (num);
-                if (plug != null && plug.strip ().down() == output_name) {
+                if (plug != null && plug.strip ().down () == output_name) {
                     unowned Gdk.Monitor monitor = display.get_monitor (num);
                     if (monitor != null) return monitor;
                 }

--- a/src/notificationWindow/notificationWindow.vala
+++ b/src/notificationWindow/notificationWindow.vala
@@ -36,6 +36,8 @@ namespace SwayNotificationCenter {
         [GtkChild]
         unowned Gtk.Box box;
 
+        private unowned Gdk.Monitor current_monitor;
+
         private bool list_reverse = false;
 
         private double last_upper = 0;
@@ -68,6 +70,16 @@ namespace SwayNotificationCenter {
         }
 
         private void set_anchor () {
+            if (swaync_daemon.use_layer_shell) {
+                // Set current monitor to display on
+                unowned Gdk.Monitor? mon
+                    = Functions.get_monitor_from_name (ConfigModel.instance.output);
+                if (mon != current_monitor) {
+                    GtkLayerShell.set_monitor (this, mon);
+                    current_monitor = mon;
+                }
+            }
+
             switch (ConfigModel.instance.positionX) {
                 case PositionX.LEFT:
                     if (!swaync_daemon.use_layer_shell) break;


### PR DESCRIPTION
Supersedes: #64 

Fixes: #62 

- [x] Choose monitor as config option
- [x] Notification window logic
- [x] Control center logic
- [ ] Test if disconnecting monitor breaks this
- [ ] Update man page
- [x] Open on focused monitor if the chosen display isn't found