### PR TITLE
Add meson_option to build without PulseAudio Widget

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -224,8 +224,10 @@ config file to be able to detect config errors
 			optional: true ++
 		*buttons-grid*++
 			optional: true ++
+#START pulse-audio
 		*volume*++
 			optional: true ++
+#END pulse-audio
 		*backlight*++
 			optional: true ++
 		*inhibitors*++
@@ -415,6 +417,7 @@ config file to be able to detect config errors
 								description: "Command to be executed on click" ++
 					description: A list of actions containing a label and a command ++
 			description: A grid of buttons that execute shell commands ++
+#START pulse-audio
 		*volume*++
 			type: object ++
 			css class: ++
@@ -463,6 +466,7 @@ config file to be able to detect config errors
 					default: 250 ++
 					description: Duration of animation in milliseconds ++
 			description: Slider to control pulse volume ++
+#END pulse-audio
 		*backlight*++
 			type: object ++
 			css class: widget-backlight ++
@@ -565,8 +569,9 @@ config file to be able to detect config errors
 	}
 }
 ```
+#START scripting
 
-# IF BUILT WITH SCRIPTING
+# Scripts
 
 *script-fail-notify* ++
 	type: bool ++
@@ -646,3 +651,4 @@ SWAYNC_REPLACES_ID="ID of notification to replace"
 SWAYNC_ID="SwayNC notification ID"
 SWAYNC_SUMMARY="Notification summary"
 ```
+#END scripting

--- a/meson.build
+++ b/meson.build
@@ -98,8 +98,21 @@ endif
 # Man pages
 if get_option('man-pages')
   scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: true)
-  if scdoc.found()
+  sed = find_program(['sed', '/usr/bin/sed'], required : true)
+  if scdoc.found() and sed.found()
     scdoc_prog = find_program(scdoc.get_variable(pkgconfig :'scdoc'), native: true)
+
+    # Remove parts of man page if necessary
+    sed_command = []
+    foreach option : ['pulse-audio', 'scripting']
+      if get_option(option) == false
+        # Removes all lines between the #START and #END lines (inclusive)
+        sed_command += ['-e', '/#START @0@/,/#END @0@/d'.format(option)]
+      else
+        # Removes the #START and #END lines
+        sed_command += ['-e', '/#START @0@/d;/#END @0@/d'.format(option)]
+      endif
+    endforeach
 
     mandir = get_option('mandir')
     man_files = [
@@ -111,17 +124,36 @@ if get_option('man-pages')
     foreach filename : man_files
       topic = filename.split('.')[-3].split('/')[-1]
       section = filename.split('.')[-2]
+      input = join_paths('man', filename)
       output = '@0@.@1@'.format(topic, section)
       message(mandir, section, '@0@/man@1@'.format(mandir, section))
 
+      # Remove parts of man page if necessary
+      if sed_command.length() > 0
+        output_stripped = '.stripped-@0@.@1@'.format(topic, section)
+        input = custom_target(
+          output_stripped,
+          input: input,
+          output: output_stripped,
+          command: [sed, sed_command],
+          install: false,
+          feed: true,
+          capture: true,
+          build_by_default: true,
+          build_always_stale: true
+        )
+      endif
+
       custom_target(
         output,
-        input: join_paths('man', filename),
+        input: input,
         output: output,
         command: scdoc_prog,
         install: true,
         feed: true,
         capture: true,
+        build_by_default: true,
+        build_always_stale: true,
         install_dir: '@0@/man@1@'.format(mandir, section)
       )
     endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('systemd-service', type: 'boolean', value: true, description: 'Install systemd user service unit.')
 option('scripting', type: 'boolean', value: true, description: 'Enable notification scripting.')
+option('pulse-audio', type: 'boolean', value: true, description: 'Provide PulseAudio Widget.')
 option('man-pages', type: 'boolean', value: true, description: 'Install all man pages.')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions.')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions.')

--- a/src/controlCenter/widgets/factory.vala
+++ b/src/controlCenter/widgets/factory.vala
@@ -26,9 +26,11 @@ namespace SwayNotificationCenter.Widgets {
             case "buttons-grid":
                 widget = new ButtonsGrid (suffix, swaync_daemon, noti_daemon);
                 break;
+#if HAVE_PULSE_AUDIO
             case "volume":
                 widget = new Volume (suffix, swaync_daemon, noti_daemon);
                 break;
+#endif
             case "backlight":
                 widget = new Backlight (suffix, swaync_daemon, noti_daemon);
                 break;

--- a/src/meson.build
+++ b/src/meson.build
@@ -40,12 +40,6 @@ widget_sources = [
   'controlCenter/widgets/menubar/menubar.vala',
   # Widget: Buttons Grid
   'controlCenter/widgets/buttonsGrid/buttonsGrid.vala',
-  # Widget: Volume
-  'controlCenter/widgets/volume/volume.vala',
-  'controlCenter/widgets/volume/pulseDaemon.vala',
-  'controlCenter/widgets/volume/pulseDevice.vala',
-  'controlCenter/widgets/volume/pulseSinkInput.vala',
-  'controlCenter/widgets/volume/sinkInputRow.vala',
   # Widget: Backlight Slider
   'controlCenter/widgets/backlight/backlight.vala',
   'controlCenter/widgets/backlight/backlightUtil.vala',
@@ -79,19 +73,34 @@ app_deps = [
   meson.get_compiler('c').find_library('m', required : true),
   meson.get_compiler('vala').find_library('posix'),
   dependency('gee-0.8'),
-  dependency('libpulse'),
-  dependency('libpulse-mainloop-glib'),
 ]
 
 # Checks if the user wants scripting enabled
 if get_option('scripting')
-    add_project_arguments('-D', 'WANT_SCRIPTING', language: 'vala')
+  add_project_arguments('-D', 'WANT_SCRIPTING', language: 'vala')
+endif
+
+# Checks if the user wants to compile with the PulseAudio dependency
+if get_option('pulse-audio')
+  add_project_arguments('-D', 'HAVE_PULSE_AUDIO', language: 'vala')
+  app_deps += [
+    dependency('libpulse'),
+    dependency('libpulse-mainloop-glib'),
+  ]
+  app_sources += [
+    # Widget: Volume
+    'controlCenter/widgets/volume/volume.vala',
+    'controlCenter/widgets/volume/pulseDaemon.vala',
+    'controlCenter/widgets/volume/pulseDevice.vala',
+    'controlCenter/widgets/volume/pulseSinkInput.vala',
+    'controlCenter/widgets/volume/sinkInputRow.vala',
+  ]
 endif
 
 # Detect libhandy version
 libhandy = dependency('libhandy-1')
 if libhandy.version() >= '1.3.9'
-    add_project_arguments('-D', 'HAVE_LATEST_LIBHANDY', language: 'vala')
+  add_project_arguments('-D', 'HAVE_LATEST_LIBHANDY', language: 'vala')
 endif
 
 # Detect gtk-layer-shell version


### PR DESCRIPTION
Fixes: #271

`meson build -Dpulse-audio=false` configures it to build without PulseAudio