### PR TITLE
Add Guix and rde installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Table of Contents
      * [OpenSUSE Tumbleweed](#opensuse-tumbleweed)
      * [Ubuntu](#ubuntu)
      * [Debian](#debian)
+     * [Guix](#guix)
+     * [rde](#rde)
      * [Other](#other)
   * [Sway Usage](#sway-usage)
   * [Run](#run)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ Bookworm and later:
 sudo apt install sway-notification-center
 ```
 
+### Guix
+
+The simplest way is to install it to user's profile:
+```
+guix install swaynotificationcenter
+```
+
+But we recommend to use [Guix Home](https://guix.gnu.org/manual/devel/en/html_node/Home-Configuration.html) to manage packages and their configurations declaratively.
+
+### rde
+```
+(use-modules (rde features wm))
+
+;; Include the following code into the list of your rde features:
+(feature-swaynotificationcenter)
+```
+
 ### Other
 
 ```zsh


### PR DESCRIPTION
Thank you for making this nice notification center! We have SwayNotificationCenter packaged in [Guix](https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/wm.scm?h=a831efb52f49a8424a915f30486730e0fd4ba4e2#n1820) and [rde](https://git.sr.ht/~abcdw/rde/tree/3b81be46d3d6891663f857172bc00b46f0e1eafa/src/rde/features/wm.scm#L906). Added respective installation instructions.