### PR TITLE
flush stdout after subscription events

### DIFF
--- a/src/client.vala
+++ b/src/client.vala
@@ -77,8 +77,9 @@ private void print_help (string[] args) {
 
 private void on_subscribe (uint count, bool dnd, bool cc_open, bool inhibited) {
     stdout.printf (
-        "{ \"count\": %u, \"dnd\": %s, \"visible\": %s, \"inhibited\": %s }\n"
-         .printf (count, dnd.to_string (), cc_open.to_string (), inhibited.to_string ()));
+        "{ \"count\": %u, \"dnd\": %s, \"visible\": %s, \"inhibited\": %s }\n",
+         count, dnd.to_string (), cc_open.to_string (), inhibited.to_string ());
+    stdout.flush ();
 }
 
 private void print_subscribe () {


### PR DESCRIPTION
Otherwise, trying to pipe its output into another command (say, `jq --unbuffered`) will make it buffer up events instead of feeding information in realtime.

Bonus: remove second printf.