### PR TITLE
allow 8 digits in 2fa code regex

### DIFF
--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -138,7 +138,7 @@ namespace SwayNotificationCenter {
 
         construct {
             try {
-                code_regex = new Regex ("(?<= |^)(\\d{3}(-| )\\d{3}|\\d{4,7})(?= |$|\\.|,)",
+                code_regex = new Regex ("(?<= |^)(\\d{3}(-| )\\d{3}|\\d{4,8})(?= |$|\\.|,)",
                                         RegexCompileFlags.MULTILINE);
                 string joined_tags = string.joinv ("|", TAGS);
                 tag_regex = new Regex ("&lt;(/?(?:%s))&gt;".printf (joined_tags));


### PR DESCRIPTION
Changed 2fa regex to allow for codes with 8 digits in a row. (My bank sends me 8-digit codes.) For now I'm happy enough patching my own build, but I thought this might be useful for other users.  