### PR TITLE
Add notification hint to bypass dnd/inhibition

### DIFF
--- a/src/notiModel/notiModel.vala
+++ b/src/notiModel/notiModel.vala
@@ -110,6 +110,9 @@ namespace SwayNotificationCenter {
         /** Disables scripting for notification */
         public bool swaync_no_script { get; set; }
 
+        /** Always show the notification, regardless of dnd/inhibit state */
+        public bool swaync_bypass_dnd { get; set; }
+
         public Array<Action> actions { get; set; }
 
         public NotifyParams (uint32 applied_id,
@@ -145,6 +148,11 @@ namespace SwayNotificationCenter {
                     case "SWAYNC_NO_SCRIPT":
                         if (hint_value.is_of_type (VariantType.BOOLEAN)) {
                             swaync_no_script = hint_value.get_boolean ();
+                        }
+                        break;
+                    case "SWAYNC_BYPASS_DND":
+                        if (hint_value.is_of_type (VariantType.BOOLEAN)) {
+                            swaync_bypass_dnd = hint_value.get_boolean ();
                         }
                         break;
                     case "value":


### PR DESCRIPTION
I use a couple scripts that trigger custom transient notifications using notify-send (e.g cycling through MPRIS players using playerctld). When I enable dnd, it unfortunately hides those notifications as well :(
I tried using `notify-send --urgency critical`, but critical notifications never expire (it overrides `--expire-time`). I tried closing the notification via dbus after a `sleep`, but that gets very messy very quickly.

Instead, I opted to add a hint to bypass swaync's dnd/inhibit mechanisms. It can be used like this:
```sh
notify-send \
  --expire-time 1000 \
  --transient \
  --hint boolean:SWAYNC_BYPASS_DND:true \
  "hello"
```

Let me know what you think :smiley: 

Oh also, should I add this to the manpage/readme? If so, where?