### PR TITLE
Add border-radius property to notification images

### DIFF
--- a/data/style/style.scss
+++ b/data/style/style.scss
@@ -98,6 +98,7 @@
           .image {
             /* Notification Primary Image */
             -gtk-icon-effect: none;
+            border-radius: 10px; /* Size in px */
           }
           .summary {
             /* Notification summary/title */

--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -262,11 +262,15 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                            source.media_player.identity);
                 }
                 if (pixbuf != null) {
-                    pixbuf = Functions.scale_round_pixbuf (pixbuf,
+                    var surface = Functions.scale_round_pixbuf (pixbuf,
                                                            mpris_config.image_size,
                                                            mpris_config.image_size,
                                                            scale,
                                                            mpris_config.image_radius);
+                    pixbuf = Gdk.pixbuf_get_from_surface (surface,
+                                                          0, 0,
+                                                          mpris_config.image_size,
+                                                          mpris_config.image_size);
                     album_art.set_from_pixbuf (pixbuf);
                     album_art.get_style_context ().set_scale (1);
                     return;

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -668,22 +668,33 @@ namespace SwayNotificationCenter {
             var app_icon_exists = File.new_for_path (
                 param.app_icon ?? "").query_exists ();
 
+            // Get the image CSS corner radius in pixels
+            int radius = 0;
+            unowned var ctx = img.get_style_context ();
+            var value = ctx.get_property (Gtk.STYLE_PROPERTY_BORDER_RADIUS,
+                                          ctx.get_state ());
+            if (value.type () == Type.INT) {
+                radius = value.get_int ();
+            }
+
             if (param.image_data.is_initialized) {
                 Functions.set_image_data (param.image_data, img,
-                                          notification_icon_size);
+                                          notification_icon_size, radius);
             } else if (param.image_path != null &&
                        param.image_path != "" &&
                        img_path_exists) {
                 Functions.set_image_path (param.image_path, img,
                                           notification_icon_size,
+                                          radius,
                                           img_path_exists);
             } else if (param.app_icon != null && param.app_icon != "") {
                 Functions.set_image_path (param.app_icon, img,
                                           notification_icon_size,
+                                          radius,
                                           app_icon_exists);
             } else if (param.icon_data.is_initialized) {
                 Functions.set_image_data (param.icon_data, img,
-                                          notification_icon_size);
+                                          notification_icon_size, radius);
             }
 
             if (img.storage_type == Gtk.ImageType.EMPTY) {


### PR DESCRIPTION
![image](https://github.com/ErikReider/SwayNotificationCenter/assets/35975961/da826d1e-78f8-4eb8-a2bd-099ea54f3e71)

Fixes: #349 