### PR TITLE
Fix text color on light theme

### DIFF
--- a/data/style/style.scss
+++ b/data/style/style.scss
@@ -286,6 +286,7 @@ $notification-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3),
 .control-center {
   /* The Control Center which contains the old notifications + widgets */
   background: #{"@cc-bg"};
+  color: #{"@text-color"};
   border-radius: $border-radius;
 
   .control-center-list-placeholder {

--- a/data/style/widgets/dnd.scss
+++ b/data/style/widgets/dnd.scss
@@ -1,4 +1,5 @@
 .widget-dnd {
+  color: #{"@text-color"};
   margin: 8px;
   font-size: 1.1rem;
 }

--- a/data/style/widgets/title.scss
+++ b/data/style/widgets/title.scss
@@ -1,4 +1,5 @@
 .widget-title {
+  color: #{"@text-color"};
   margin: 8px;
   font-size: 1.5rem;
 }


### PR DESCRIPTION
#361
This applies to the changes I made to style.css to the default stylesheets, so that it would use @text-color for the color of the title text and control center text. Please test this before merging.