### PR TITLE
Fix mpris icon size when using app or default icon

### DIFF
--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -380,12 +380,13 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                 icon = desktop_entry.get_icon ();
             }
             if (icon != null) {
-                album_art.set_from_gicon (icon, mpris_config.image_size);
+                album_art.set_from_gicon (icon, Gtk.IconSize.DIALOG);
             } else {
                 // Default icon
                 album_art.set_from_icon_name ("audio-x-generic-symbolic",
-                                              mpris_config.image_size);
+                                              Gtk.IconSize.DIALOG);
             }
+            album_art.set_pixel_size(mpris_config.image_size);
         }
 
         private void update_button_shuffle (HashTable<string, Variant> metadata) {


### PR DESCRIPTION
set_from_gicon and set_from_icon_name receive a Gtk.IconSize enum value,
not an int, so we need to call set_pixel_size to set the proper size.
