### PR TITLE
Allow running binaries without installing schemas

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -4,6 +4,8 @@ install_data('org.erikreider.swaync.gschema.xml',
 
 subdir('icons')
 
+gnome.compile_schemas()
+
 compile_schemas = find_program('glib-compile-schemas', required: false)
 if compile_schemas.found()
   test('Validate schema file', compile_schemas,


### PR DESCRIPTION
This allows using `meson devenv` to run the binaries without having to
install the schemas or manually setup XDG_DATA_PATH, which is usefull
during development.

`gnome.compile_schemas()` does not affect the installation, only `meson devenv`.