### PR TITLE
Allows Variable Notification Window Height

### DIFF
--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -406,6 +406,12 @@ namespace SwayNotificationCenter {
          */
         public int notification_window_width { get; set; default = 500; }
 
+
+        /**
+         * Notification window's height, in pixels.
+         */
+        public int notification_window_height { get; set; default = 800; }
+
         /** Hides the control center after clearing all notifications */
         public bool hide_on_clear { get; set; default = false; }
 

--- a/src/notificationWindow/notificationWindow.vala
+++ b/src/notificationWindow/notificationWindow.vala
@@ -42,7 +42,7 @@ namespace SwayNotificationCenter {
 
         Gee.HashSet<uint32> inline_reply_notifications = new Gee.HashSet<uint32> ();
 
-        private const int MAX_HEIGHT = 600;
+        private int MAX_HEIGHT = ConfigModel.instance.notification_window_height;
 
         private NotificationWindow () {
             if (swaync_daemon.use_layer_shell) {


### PR DESCRIPTION
Allows Variable Notification Window Height

Solves:

@/issues/174
@/issues/274
@/issues/177

![swayncwindowheight](https://github.com/ErikReider/SwayNotificationCenter/assets/165446573/c78c4dbf-17e2-480a-8f5d-7c77a5e668a0)
