### PR TITLE
Update README.md with the swaync Arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ These widgets can be customized, added, removed and even reordered
 
 ### Arch
 
-The package is available on the AUR:
+```zsh
+sudo pacman -S swaync
+```
 
-- [swaync](https://aur.archlinux.org/packages/swaync/)
-- [swaync-git](https://aur.archlinux.org/packages/swaync-git/)
+Alternatively, [swaync-git](https://aur.archlinux.org/packages/swaync-git/) is available on the AUR.
 
 ### Fedora
 


### PR DESCRIPTION
Hi,

Swaync is now in the Arch Linux [[extra] repository](https://archlinux.org/packages/extra/x86_64/swaync/).
This commit updates the README accordingly :smile: 

Thanks for you wonderful work with Swaync!