### PR TITLE
add settings to center buttons-grid

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -135,7 +135,7 @@ config file to be able to detect config errors
 	type: bool ++
 	default: true ++
 	description: Display notification timestamps relative to now e.g. \"26 minutes ago\". ++
-		If false, a local iso8601-formatted absolute timestamp is displayed. 
+		If false, a local iso8601-formatted absolute timestamp is displayed.
 
 *control-center-height* ++
 	type: integer ++
@@ -442,6 +442,21 @@ config file to be able to detect config errors
 			type: object ++
 			css class: widget-buttons (access buttons with >flowbox>flowboxchild>button) ++
 			properties: ++
+				center: ++
+					type: bool ++
+					optional: true ++
+					default: false ++
+					description: set buttons-grid halign to center ++
+				column-min: ++
+					type: integer ++
+					optional: true ++
+					default: 0 ++
+					description: minimum number of buttons per line ++
+				column-max: ++
+					type: integer ++
+					optional: true ++
+					default: 0 ++
+					description: maximum number of buttons per line ++
 				actions: ++
 					type: array ++
 					Default values: [] ++

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -418,15 +418,20 @@
       "description": "A widget to add a grid of buttons that execute shell commands",
       "additionalProperties": false,
       "properties": {
+        "center": {
+          "type": "boolean",
+          "description": "set buttons-grid halign to center",
+          "default": false
+        },
         "column-min": {
           "type": "integer",
           "description": "minimum number of buttons per line",
-          "default": 4
+          "default": 0
         },
         "column-max": {
           "type": "integer",
           "description": "maximum number of buttons per line",
-          "default": 7
+          "default": 0
         },
         "actions": {
           "type": "array",

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -418,6 +418,16 @@
       "description": "A widget to add a grid of buttons that execute shell commands",
       "additionalProperties": false,
       "properties": {
+        "column-min": {
+          "type": "integer",
+          "description": "minimum number of buttons per line",
+          "default": 4
+        },
+        "column-max": {
+          "type": "integer",
+          "description": "maximum number of buttons per line",
+          "default": 7
+        },
         "actions": {
           "type": "array",
           "description": "A list of actions containing a label and a command",

--- a/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
+++ b/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
@@ -15,26 +15,27 @@ namespace SwayNotificationCenter.Widgets {
         public ButtonsGrid (string suffix, SwayncDaemon swaync_daemon, NotiDaemon noti_daemon) {
             base (suffix, swaync_daemon, noti_daemon);
 
-            int column_min = 4;
-            int column_max = 7;
+            Gtk.FlowBox container = new Gtk.FlowBox ();
+            container.set_selection_mode (Gtk.SelectionMode.NONE);
+            pack_start (container, true, true, 0);
 
             Json.Object ? config = get_config (this);
             if (config != null) {
                 Json.Array a = get_prop_array (config, "actions");
                 if (a != null) actions = parse_actions (a);
 
-                int? col_min = get_prop<int> (config, "column-min");
-                if (col_min != null) column_min = col_min;
-                int? col_max = get_prop<int> (config, "column-max");
-                if (col_max != null) column_max = col_max;
-            }
+                bool? center = get_prop<bool> (config, "center");
+                if (center != null && center)
+                    container.set_halign(Gtk.Align.CENTER);
 
-            Gtk.FlowBox container = new Gtk.FlowBox ();
-            container.set_selection_mode (Gtk.SelectionMode.NONE);
-            container.set_halign(Gtk.Align.CENTER);
-            container.set_min_children_per_line(column_min);
-            container.set_max_children_per_line(column_max);
-            pack_start (container, true, true, 0);
+                int? col_min = get_prop<int> (config, "column-min");
+                if (col_min != null && col_min > 0)
+                    container.set_min_children_per_line(col_min);
+
+                int? col_max = get_prop<int> (config, "column-max");
+                if (col_max != null && col_max > 0)
+                    container.set_max_children_per_line(col_max);
+            }
 
             // add action to container
             foreach (var act in actions) {

--- a/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
+++ b/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
@@ -22,25 +22,30 @@ namespace SwayNotificationCenter.Widgets {
             Json.Object ? config = get_config (this);
             if (config != null) {
                 Json.Array a = get_prop_array (config, "actions");
-                if (a != null) actions = parse_actions (a);
+                if (a != null) {
+                    actions = parse_actions (a);
+                }
 
-                bool? center = get_prop<bool> (config, "center");
-                if (center != null && center)
-                    container.set_halign(Gtk.Align.CENTER);
+                bool ? center = get_prop<bool> (config, "center");
+                if (center != null && center) {
+                    container.set_halign (Gtk.Align.CENTER);
+                }
 
-                int? col_min = get_prop<int> (config, "column-min");
-                if (col_min != null && col_min > 0)
-                    container.set_min_children_per_line(col_min);
+                int ? col_min = get_prop<int> (config, "column-min");
+                if (col_min != null && col_min > 0) {
+                    container.set_min_children_per_line (col_min);
+                }
 
-                int? col_max = get_prop<int> (config, "column-max");
-                if (col_max != null && col_max > 0)
-                    container.set_max_children_per_line(col_max);
+                int ? col_max = get_prop<int> (config, "column-max");
+                if (col_max != null && col_max > 0) {
+                    container.set_max_children_per_line (col_max);
+                }
             }
 
             // add action to container
             foreach (var act in actions) {
                 switch (act.type) {
-                    case ButtonType.TOGGLE:
+                    case ButtonType.TOGGLE :
                         ToggleButton tb = new ToggleButton (act.label, act.command, act.update_command, act.active);
                         container.insert (tb, -1);
                         toggle_buttons.append (tb);

--- a/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
+++ b/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
@@ -15,14 +15,25 @@ namespace SwayNotificationCenter.Widgets {
         public ButtonsGrid (string suffix, SwayncDaemon swaync_daemon, NotiDaemon noti_daemon) {
             base (suffix, swaync_daemon, noti_daemon);
 
+            int column_min = 4;
+            int column_max = 7;
+
             Json.Object ? config = get_config (this);
             if (config != null) {
                 Json.Array a = get_prop_array (config, "actions");
                 if (a != null) actions = parse_actions (a);
+
+                int? col_min = get_prop<int> (config, "column-min");
+                if (col_min != null) column_min = col_min;
+                int? col_max = get_prop<int> (config, "column-max");
+                if (col_max != null) column_max = col_max;
             }
 
             Gtk.FlowBox container = new Gtk.FlowBox ();
             container.set_selection_mode (Gtk.SelectionMode.NONE);
+            container.set_halign(Gtk.Align.CENTER);
+            container.set_min_children_per_line(column_min);
+            container.set_max_children_per_line(column_max);
             pack_start (container, true, true, 0);
 
             // add action to container


### PR DESCRIPTION
buttonsGrid is using flowbox as the container, with default halign set
to FILL, for which users have to tweak the button size to make it really
fill the space or it will not be centered.

This adds options to make the buttonGrid centered properly