### PR TITLE
Mpris: add blacklist support, fix setup_mpris(), sync doc

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -330,6 +330,17 @@ config file to be able to detect config errors
 					optional: true ++
 					default: 12 ++
 					description: The border radius of the album art. ++
+				blur: ++
+					type: bool ++
+					optional: true ++
+					default: true ++
+					description: Appy the artwork as the MPRIS background and blur it ++
+				blacklist: ++
+					type: array ++
+					optional: true ++
+					default: [] ++
+					description: Mpris players to be ignored, without the bus name prefix. ++
+						you may check with `qdbus|grep -i mpris` ++
 			description: A widget that displays multiple music players. ++
 		*menubar*++
 			type: object ++
@@ -595,7 +606,8 @@ config file to be able to detect config errors
 		},
 		"mpris": {
 			"image-size": 96,
-			"image-radius": 12
+			"image-radius": 12,
+			"blacklist": ["playerctld"]
 		},
 		"menubar": {
 			"menu#power": {

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -410,6 +410,15 @@
           "type": "boolean",
           "description": "Appy the artwork as the MPRIS background and blur it",
           "default": true
+        },
+        "blacklist": {
+          "type": "array",
+          "description": "Mpris players to be ignored, without the bus name prefix",
+          "default": [],
+          "items": {
+            "type": "string",
+            "description": "Basename of mpris bus name, Uses Regex."
+          }
         }
       }
     },

--- a/src/controlCenter/widgets/mpris/mpris.vala
+++ b/src/controlCenter/widgets/mpris/mpris.vala
@@ -3,6 +3,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
         int image_size;
         int image_radius;
         bool blur;
+        string[] blacklist;
     }
 
     public class Mpris : BaseWidget {
@@ -99,6 +100,13 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                 bool blur_found;
                 bool? blur = get_prop<bool> (config, "blur", out blur_found);
                 if (blur_found) mpris_config.blur = blur;
+
+                Json.Array ? blacklist = get_prop_array (config, "blacklist");
+                if (blacklist != null) {
+                    mpris_config.blacklist = new string[blacklist.get_length ()];
+                    for (int i = 0; i < blacklist.get_length (); i++)
+                        mpris_config.blacklist[i] = blacklist.get_string_element (i);
+                }
             }
 
             hide ();
@@ -174,6 +182,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
             string[] names = dbus_iface.list_names ();
             foreach (string name in names) {
                 if (!name.has_prefix (MPRIS_PREFIX)) continue;
+                if (is_blacklisted (name)) return;
                 if (check_player_exists (name)) return;
                 MprisSource ? source = MprisSource.get_player (name);
                 if (source != null) add_player (name, source);
@@ -185,10 +194,20 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                     remove_player (name);
                     return;
                 }
+                if (is_blacklisted (name)) return;
                 if (check_player_exists (name)) return;
                 MprisSource ? source = MprisSource.get_player (name);
                 if (source != null) add_player (name, source);
             });
+        }
+
+        private bool is_blacklisted (string name) {
+            foreach (string blacklistedPattern in mpris_config.blacklist) {
+                string fullPattern = MPRIS_PREFIX + blacklistedPattern;
+                if (GLib.Regex.match_simple (fullPattern, name))
+                    return true;
+            }
+            return false;
         }
 
         private bool check_player_exists (string name) {

--- a/src/controlCenter/widgets/mpris/mpris.vala
+++ b/src/controlCenter/widgets/mpris/mpris.vala
@@ -182,8 +182,8 @@ namespace SwayNotificationCenter.Widgets.Mpris {
             string[] names = dbus_iface.list_names ();
             foreach (string name in names) {
                 if (!name.has_prefix (MPRIS_PREFIX)) continue;
-                if (is_blacklisted (name)) return;
-                if (check_player_exists (name)) return;
+                if (is_blacklisted (name)) continue;
+                if (check_player_exists (name)) continue;
                 MprisSource ? source = MprisSource.get_player (name);
                 if (source != null) add_player (name, source);
             }


### PR DESCRIPTION
1. blacklist support is based on [this PR](https://github.com/ErikReider/SwayNotificationCenter/pull/390)
2. fix unintended return in `setup_mpris()`, which should resolve [this issue](https://github.com/ErikReider/SwayNotificationCenter/issues/425)
3. sync schema and man page