### PR TITLE
Add an option to ignore left click on a notification

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -80,6 +80,11 @@ config file to be able to detect config errors
 	default: true ++
 	description: If each notification should display a 'COPY \"1234\"' action
 
+*notification-ignore-left-click* ++
+	type: bool ++
+	default: false ++
+	description: If notification should be closed on left click. This does not affect sliding behavior
+
 *timeout* ++
 	type: integer ++
 	default: 10 ++

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -546,6 +546,11 @@ namespace SwayNotificationCenter {
         public bool notification_2fa_action { get; set; default = true; }
 
         /**
+         * If notification should be closed on left click. This does not affect sliding behavior
+         */
+        public bool notification_ignore_left_click { get; set; default = false; }
+
+        /**
          * If notifications should display a text field to reply if the
          * sender requests it.
          */

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -85,6 +85,11 @@
       "description": "If each notification should display a 'COPY \"1234\"' action",
       "default": true
     },
+    "notification-ignore-left-click": {
+      "type": "boolean",
+      "description": "If notification should be closed on left click. This does not affect sliding behavior",
+      "default": false
+    },
     "notification-inline-replies": {
       "type": "boolean",
       "description": "If notifications should display a text field to reply if the sender requests it. NOTE: Replying in popup notifications is only available if the compositor supports GTK Layer-Shell ON_DEMAND keyboard interactivity.",

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -167,7 +167,7 @@ namespace SwayNotificationCenter {
                 // Emit released
                 if (!default_action_down) return;
                 default_action_down = false;
-                if (default_action_in) {
+                if (default_action_in && !ConfigModel.instance.notification_ignore_left_click) {
                     click_default_action ();
                 }
 


### PR DESCRIPTION
This PR add the ability to ignore left click on a notification.

Currently when a notification itself (not action button, close button, etc.) receives left click, it closes. It's not always useful, because when trying to reply to a message within the notification, you have to aim input field. Sometimes you miss it and notification closes without an option to restore it or reply after closing.

This PR tries to fix it by introducing an option to ignore left click on notification body.