### PR TITLE
hints: parse sound-name and sound-file

### DIFF
--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -73,6 +73,8 @@ namespace SwayNotificationCenter {
         public string ? body { get; set; default = null; }
         public string ? urgency { get; set; default = null; }
         public string ? category { get; set; default = null; }
+        public string ? sound_name { get; set; default = null; }
+        public string ? sound_file { get; set; default = null; }
 
         private const RegexCompileFlags REGEX_COMPILE_OPTIONS =
             RegexCompileFlags.MULTILINE
@@ -124,6 +126,22 @@ namespace SwayNotificationCenter {
                 if (param.category == null) return false;
                 bool result = Regex.match_simple (
                     category, param.category,
+                    REGEX_COMPILE_OPTIONS,
+                    REGEX_MATCH_FLAGS);
+                if (!result) return false;
+            }
+            if (sound_file != null) {
+                if (param.sound_file == null) return false;
+                bool result = Regex.match_simple (
+                    sound_file, param.sound_file,
+                    REGEX_COMPILE_OPTIONS,
+                    REGEX_MATCH_FLAGS);
+                if (!result) return false;
+            }
+            if (sound_name != null) {
+                if (param.sound_name == null) return false;
+                bool result = Regex.match_simple (
+                    sound_name, param.sound_name,
                     REGEX_COMPILE_OPTIONS,
                     REGEX_MATCH_FLAGS);
                 if (!result) return false;
@@ -243,6 +261,8 @@ namespace SwayNotificationCenter {
             spawn_env += "SWAYNC_BODY=%s".printf (param.body);
             spawn_env += "SWAYNC_URGENCY=%s".printf (param.urgency.to_string ());
             spawn_env += "SWAYNC_CATEGORY=%s".printf (param.category);
+            spawn_env += "SWAYNC_SOUND_NAME=%s".printf (param.sound_name);
+            spawn_env += "SWAYNC_SOUND_FILE=%s".printf (param.sound_file);
             spawn_env += "SWAYNC_ID=%s".printf (param.applied_id.to_string ());
             spawn_env += "SWAYNC_REPLACES_ID=%s".printf (param.replaces_id.to_string ());
             spawn_env += "SWAYNC_TIME=%s".printf (param.time.to_string ());

--- a/src/notiModel/notiModel.vala
+++ b/src/notiModel/notiModel.vala
@@ -82,6 +82,8 @@ namespace SwayNotificationCenter {
         public string image_path { get; set; }
         public string desktop_entry { get; set; }
         public string category { get; set; }
+        public string sound_name { get; set; }
+        public string sound_file { get; set; }
         public bool resident { get; set; }
         public bool transient { get; set; }
         public UrgencyLevels urgency { get; set; }
@@ -250,6 +252,16 @@ namespace SwayNotificationCenter {
                             category = hint_value.get_string ();
                         }
                         break;
+                    case "sound-name":
+                        if (hint_value.is_of_type (VariantType.STRING)) {
+                            sound_name = hint_value.get_string ();
+                        }
+                        break;
+                    case "sound-file":
+                        if (hint_value.is_of_type (VariantType.STRING)) {
+                            sound_file = hint_value.get_string ();
+                        }
+                        break;
                     case "resident":
                         if (hint_value.is_of_type (VariantType.BOOLEAN)) {
                             resident = hint_value.get_boolean ();
@@ -336,6 +348,8 @@ namespace SwayNotificationCenter {
             params.set ("image_path", image_path);
             params.set ("desktop_entry", desktop_entry);
             params.set ("category", category);
+            params.set ("sound_name", sound_name);
+            params.set ("sound_file", sound_file);
             params.set ("resident", resident.to_string ());
             params.set ("urgency", urgency.to_string ());
             string[] _actions = {};


### PR DESCRIPTION
On mobile devices, it can be helpful to play the audio sound indicated by the notification's hint.


This allows for minimal audio-capabilities (without including another library).

Example config:

```json
{
	"scripts": {
		"sound-name": {
			"exec": "sh -c 'mpv --really-quiet /usr/share/sounds/freedesktop/stereo/$SWAYNC_SOUND_NAME.oga'",
			"sound-name": "."
		},
		"sound-file": {
			"exec": "sh -c 'mpv --really-quiet \"$SWAYNC_SOUND_FILE\"'",
			"sound-file": "."
		}
	}
}
```

run `notify-send "Where am I?" -h STRING:sound-name:audio-channel-front-right`

or `notify-send "Where am I?" -h STRING:sound-file:/usr/share/sounds/freedesktop/stereo/audio-channel-front-left.oga`

(Similar to https://github.com/emersion/mako/pull/470)

See also #58