### PR TITLE
Fix json parsing error in config.json

### DIFF
--- a/src/config.json.in
+++ b/src/config.json.in
@@ -74,7 +74,7 @@
     },
     "mpris": {
       "image-size": 96,
-      "image-radius": 12
+      "image-radius": 12,
       "blacklist": []
     },
     "buttons-grid": {


### PR DESCRIPTION
When launching swaync:
```
** (swaync:867354): CRITICAL **: 17:12:29.374: configModel.vala:310: /etc/xdg/swaync/config.json:77:24: Parse error: unexpected number `12', expected character `,'
```
This PR fixes this error.