### PR TITLE
fix: no convert upper case for the first character

### DIFF
--- a/src/notiModel/notiModel.vala
+++ b/src/notiModel/notiModel.vala
@@ -168,7 +168,7 @@ namespace SwayNotificationCenter {
             // Set name_id
             this.name_id = this.desktop_entry ?? this.app_name ?? "";
 
-            // Set display_name and make the first letter upper case
+            // Set display_name
             string ? display_name = this.desktop_entry ?? this.app_name;
             if (desktop_app_info != null) {
                 display_name = desktop_app_info.get_display_name ();
@@ -176,7 +176,7 @@ namespace SwayNotificationCenter {
             if (display_name == null || display_name.length == 0) {
                 display_name = "Unknown";
             }
-            this.display_name = display_name.splice (0, 1, display_name.up (1));
+            this.display_name = display_name;
         }
 
         private void parse_hints () {


### PR DESCRIPTION
If the app name is not ASCII, it could add extra invalid bytes to the name string