### PR TITLE
Add --hide-all option

### DIFF
--- a/completions/bash/swaync-client
+++ b/completions/bash/swaync-client
@@ -45,6 +45,7 @@ _swaync-client() {
         --inhibitors-clear
         --count
         --hide-latest
+        --hide-all
         --close-latest
         --close-all
         --skip-wait

--- a/completions/fish/swaync-client.fish
+++ b/completions/fish/swaync-client.fish
@@ -17,6 +17,7 @@ complete -c swaync-client -s Ir -l inhibitor-remove --description "Remove an inh
 complete -c swaync-client -s Ic -l inhibitors-clear --description "Clears all inhibitors" -r
 complete -c swaync-client -s c -l count --description "Print the current notification count" -r
 complete -c swaync-client      -l hide-latest --description "Hides latest notification. Still shown in Control Center" -r
+complete -c swaync-client      -l hide-all --description "Hides all notifications. Still shown in Control Center" -r
 complete -c swaync-client      -l close-latest --description "Closes latest notification" -r
 complete -c swaync-client -s C -l close-all --description "Closes all notifications" -r
 complete -c swaync-client -s sw -l skip-wait --description "Doesn't wait when swaync hasn't been started" -r

--- a/completions/zsh/_swaync-client
+++ b/completions/zsh/_swaync-client
@@ -18,9 +18,10 @@ _arguments -s \
     '(-Ir --inhibitor-remove)'{-Ir,--inhibitor-remove}'[Remove an inhibitor]' \
     '(-Ic --inhibitors-clear)'{-Ic,--inhibitors-clear}'[Clears all inhibitors]' \
     '(-c --count)'{-c,--count}'[Print the current notification count]' \
-    '(--hide-latest)'--hide-latest'[Closes all notifications]' \
-    '(--close-latest)'--close-latest'[Hides latest notification. Still shown in Control Center]' \
-    '(-C --close-all)'{-C,--close-all}'[Closes latest notification]' \
+    '(--hide-latest)'--hide-latest'[Hides latest notification. Still shown in Control Center]' \
+    '(--hide-all)'--hide-all'[Hides all notifications. Still shown in Control Center]' \
+    '(--close-latest)'--close-latest'[Closes latest notification]' \
+    '(-C --close-all)'{-C,--close-all}'[Closes all notifications]' \
     '(-sw --skip-wait)'{-sw,--skip-wait}"[Doesn't wait when swaync hasn't been started]" \
     '(-s --subscribe)'{-s,--subscribe}'[Subscribe to notification add and close events]' \
     '(-swb --subscribe-waybar)'{-swb,--subscribe-waybar}'[Subscribe to notification add and close events with waybar support. Read README for example]' \

--- a/man/swaync-client.1.scd
+++ b/man/swaync-client.1.scd
@@ -64,6 +64,9 @@ swaync-client - Client executable
 *--hide-latest*
 	Hides latest notification. Still shown in Control Center
 
+*--hide-all*
+	Hides all notifications. Still shown in Control Center
+
 *--close-latest*
 	Closes latest notification
 

--- a/src/client.vala
+++ b/src/client.vala
@@ -14,6 +14,8 @@ interface CcDaemon : Object {
 
     public abstract void hide_latest_notifications (bool close) throws DBusError, IOError;
 
+    public abstract void hide_all_notifications () throws DBusError, IOError;
+
     public abstract void close_all_notifications () throws DBusError, IOError;
 
     public abstract uint notification_count () throws DBusError, IOError;
@@ -69,6 +71,7 @@ private void print_help (string[] args) {
     print ("  -Ic, \t --inhibitors-clear \t\t Clears all inhibitors\n");
     print ("  -c, \t --count \t\t\t Print the current notification count\n");
     print ("      \t --hide-latest \t\t\t Hides latest notification. Still shown in Control Center\n");
+    print ("      \t --hide-all \t\t\t Hides all notifications. Still shown in Control Center\n");
     print ("      \t --close-latest \t\t Closes latest notification\n");
     print ("  -C, \t --close-all \t\t\t Closes all notifications\n");
     print ("  -a, \t --action [ACTION_INDEX]\t Invokes the action [ACTION_INDEX] of the latest notification\n");
@@ -158,6 +161,9 @@ public int command_line (string[] args) {
                 break;
             case "--hide-latest":
                 cc_daemon.hide_latest_notifications (false);
+                break;
+            case "--hide-all":
+                cc_daemon.hide_all_notifications ();
                 break;
             case "--close-all":
             case "-C":

--- a/src/notiDaemon/notiDaemon.vala
+++ b/src/notiDaemon/notiDaemon.vala
@@ -88,6 +88,16 @@ namespace SwayNotificationCenter {
             manually_close_notification (id, !close);
         }
 
+        /** Closes all popup notifications */
+        public void hide_all_notifications ()
+        throws DBusError, IOError {
+            while (true) {
+                uint32 ? id = NotificationWindow.instance.get_latest_notification ();
+                if (id == null) return;
+                manually_close_notification (id, true);
+            }
+        }
+
         /** Activates the `action_index` action of the latest notification */
         public void latest_invoke_action (uint32 action_index)
         throws DBusError, IOError {

--- a/src/swayncDaemon/swayncDaemon.vala
+++ b/src/swayncDaemon/swayncDaemon.vala
@@ -215,6 +215,12 @@ namespace SwayNotificationCenter {
             noti_daemon.hide_latest_notification (close);
         }
 
+        /** Closes all popup notifications */
+        public void hide_all_notifications ()
+        throws DBusError, IOError {
+            noti_daemon.hide_all_notifications ();
+        }
+
         /** Closes all popup and controlcenter notifications */
         public void close_all_notifications () throws DBusError, IOError {
             noti_daemon.close_all_notifications ();


### PR DESCRIPTION
This PR add the `--hide-all` option to the client that will close all notifications currently displayed but keep them in the control center.