### PR TITLE
feat(mpris): autohide

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -344,6 +344,12 @@ config file to be able to detect config errors
 						type: string ++
 						description: Audio source/app name. Regex alowed. Hint ++
 							`$ qdbus | grep mpris` to find source names. ++
+				autohide: ++
+					type: bool ++
+					optional: true ++
+					default: false ++
+					description: Whether to hide the widget when the ++
+								 player has no metadata. ++
 			description: A widget that displays multiple music players. ++
 		*menubar*++
 			type: object ++
@@ -610,7 +616,8 @@ config file to be able to detect config errors
 		"mpris": {
 			"image-size": 96,
 			"image-radius": 12,
-			"blacklist": ["playerctld"]
+			"blacklist": ["playerctld"],
+			"autohide": true
 		},
 		"menubar": {
 			"menu#power": {

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -76,7 +76,8 @@
     "mpris": {
       "image-size": 96,
       "image-radius": 12,
-      "blacklist": []
+      "blacklist": [],
+      "autohide": false
     },
     "buttons-grid": {
       "actions": [

--- a/src/controlCenter/widgets/mpris/interfaces.vala
+++ b/src/controlCenter/widgets/mpris/interfaces.vala
@@ -9,8 +9,8 @@ namespace SwayNotificationCenter.Widgets.Mpris {
 
         public const string INTERFACE_PATH = "/org/mpris/MediaPlayer2";
 
-        private MprisSource (MprisMediaPlayer _meddia_player, DbusPropChange _props) {
-            this.media_player = _meddia_player;
+        private MprisSource (MprisMediaPlayer _media_player, DbusPropChange _props) {
+            this.media_player = _media_player;
             this.props = _props;
             this.props.properties_changed.connect (
                 (i, c, inv) => properties_changed (i, c, inv));

--- a/src/controlCenter/widgets/mpris/mpris.vala
+++ b/src/controlCenter/widgets/mpris/mpris.vala
@@ -219,7 +219,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                         remove_player_from_carousel (name);
                     }
                 });
-                if(check_player_metadata_empty (name)) return;
+                if (check_player_metadata_empty (name)) return;
             }
 
             add_player_to_carousel (name);

--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -43,6 +43,8 @@ namespace SwayNotificationCenter.Widgets.Mpris {
 
         private unowned Config mpris_config;
 
+        public signal void content_updated ();
+
         public MprisPlayer (MprisSource source, Config mpris_config) {
             Object (source: source);
             this.mpris_config = mpris_config;
@@ -228,6 +230,10 @@ namespace SwayNotificationCenter.Widgets.Mpris {
 
             // Update the buttons
             update_buttons (metadata);
+
+            // Emit signal
+            content_updated ();
+
         }
 
         private void update_buttons (HashTable<string, Variant> metadata) {


### PR DESCRIPTION
This PR implements an autohide feature for the mpris widget. If it is enabled, players which don't supply any metadata information are dropped from the carousel.

Example config:

```jsonc
{
  // ...
  "widget-config": {
    // ...
    "mpris": {
      "image-size": 96,
      "image-radius": 12,
      "blacklist": [ "playerctld" ],
      "autohide": true
    }
    // ...
  }
  // ...
}
```

Consider an mpd to dbus bridge, such as [mpdris2-rs](https://github.com/szclsya/mpdris2-rs). When the current playlist (the "queue") is empty, `org.mpris.MediaPlayer2.Player.Metadata` is an empty dict.

```bash
$ mpc clear
volume: n/a   repeat: off   random: off   single: off   consume: off
$ mpc playlist
$ playerctl metadata
No player could handle this command
$ gdbus call -e \
        -d org.mpris.MediaPlayer2.mpd \
        -m org.freedesktop.DBus.Properties.Get \
        -o /org/mpris/MediaPlayer2 \
        org.mpris.MediaPlayer2.Player Metadata
(<@a{sv} {}>,)
```

In such cases, the mpris widget shows the default title `"Media Player"` and the default icon `audio-x-generic-symbolic` until a song is queued:

![Before autohide](https://github.com/user-attachments/assets/d85861d6-a4eb-404e-938e-d9e5b07d99c7)

This PR adds the `autohide` feature. When it is enabled, the player is hidden in such cases:

![after_autohide](https://github.com/user-attachments/assets/16942db2-f4e0-40fe-b5bb-31f4ee98c7fa)

If more than one player is active (say, mpdris2-rs + firefox), only those players which supply metadata information are shown (in this case, firefox):

![after_autohide_2](https://github.com/user-attachments/assets/b8109fdb-bcef-47cb-87c6-4c0fefe2e8a2)

