### PR TITLE
Add option for notification group header icon size

### DIFF
--- a/src/config.json.in
+++ b/src/config.json.in
@@ -16,6 +16,7 @@
   "notification-icon-size": 64,
   "notification-body-image-height": 100,
   "notification-body-image-width": 200,
+  "notification-group-header-icon-size": 32,
   "timeout": 10,
   "timeout-low": 5,
   "timeout-critical": 0,

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -631,6 +631,23 @@ namespace SwayNotificationCenter {
             }
         }
 
+
+        /**
+         * Notification Group Header icon size, in pixels.
+         */
+        private const int NOTIFICATION_GROUP_HEADER_ICON_MINIMUM_SIZE = 16;
+        private const int NOTIFICATION_GROUP_HEADER_ICON_DEFAULT_SIZE = 32;
+        private int _notification_group_header_icon_size = NOTIFICATION_GROUP_HEADER_ICON_DEFAULT_SIZE;
+        public int notification_group_header_icon_size {
+            get {
+                return _notification_group_header_icon_size;
+            }
+            set {
+                _notification_group_header_icon_size = value > NOTIFICATION_GROUP_HEADER_ICON_MINIMUM_SIZE
+                    ? value : NOTIFICATION_GROUP_HEADER_ICON_MINIMUM_SIZE;
+            }
+        }
+
         /** Widgets to show in ControlCenter */
         public GenericArray<string> widgets {
             get;

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -113,6 +113,12 @@
       "default": 200,
       "minimum": 200
     },
+    "notification-group-header-icon-size": {
+      "type": "integer",
+      "description": "The notification group header icon size (in pixels).",
+      "default": 32,
+      "minimum": 16
+    },
     "timeout": {
       "type": "integer",
       "description": "The notification timeout for notifications with normal priority",

--- a/src/notificationGroup/notificationGroup.vala
+++ b/src/notificationGroup/notificationGroup.vala
@@ -20,6 +20,8 @@ namespace SwayNotificationCenter {
         private HashTable<uint32, bool> urgent_notifications
             = new HashTable<uint32, bool> (direct_hash, direct_equal);
 
+        private int notification_group_header_icon_size { get; default=ConfigModel.instance.notification_group_header_icon_size;}
+
         public signal void on_expand_change (bool state);
 
         public NotificationGroup (string name_id, string display_name) {
@@ -85,7 +87,7 @@ namespace SwayNotificationCenter {
             start_box.add_css_class ("notification-group-headers");
             // App Icon
             app_icon = new Gtk.Image ();
-            app_icon.set_pixel_size (32);
+            app_icon.set_pixel_size (notification_group_header_icon_size);
             app_icon.set_valign (Gtk.Align.CENTER);
             app_icon.add_css_class ("notification-group-icon");
             start_box.append (app_icon);


### PR DESCRIPTION
This change adds a new configuration option, notification-group-header-icon-size, with a default value of 32. 

It allows users to customize the size of the header icon displayed in notification groups.