### PR TITLE
Add option to hide the MPRIS album art

### DIFF
--- a/src/config.json.in
+++ b/src/config.json.in
@@ -13,7 +13,6 @@
   "control-center-margin-left": 0,
   "notification-2fa-action": true,
   "notification-inline-replies": false,
-  "notification-icon-size": 64,
   "notification-body-image-height": 100,
   "notification-body-image-width": 200,
   "timeout": 10,
@@ -74,9 +73,9 @@
       "text": "Label Text"
     },
     "mpris": {
-      "image-size": 96,
       "blacklist": [],
-      "autohide": false
+      "autohide": false,
+      "show-album-art": "always"
     },
     "buttons-grid": {
       "actions": [

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -415,6 +415,12 @@
           "deprecated": true,
           "description": "deprecated (change the CSS root variable \"--mpris-album-art-icon-size\"): The size of the album art",
           "default": -1
+        },
+        "show-album-art": {
+          "type": "string",
+          "description": "Whether or not the album art should be hidden, always visible, or only visible when a valid album art is provided.",
+          "default": "always",
+          "enum": ["always", "when-available", "never"]
         }
       }
     },

--- a/src/controlCenter/widgets/mpris/mpris.vala
+++ b/src/controlCenter/widgets/mpris/mpris.vala
@@ -1,7 +1,24 @@
 namespace SwayNotificationCenter.Widgets.Mpris {
+    public enum AlbumArtState {
+        ALWAYS, WHEN_AVAILABLE, NEVER;
+
+        public static AlbumArtState parse (string value) {
+            switch (value) {
+                default:
+                case "always":
+                    return AlbumArtState.ALWAYS;
+                case "when-available":
+                    return AlbumArtState.WHEN_AVAILABLE;
+                case "never":
+                    return AlbumArtState.NEVER;
+            }
+        }
+    }
+
     public struct Config {
         [Version (deprecated = true, replacement = "CSS root variable")]
         int image_size;
+        AlbumArtState show_album_art;
         bool autohide;
         string[] blacklist;
     }
@@ -29,6 +46,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
         // Default config values
         Config mpris_config = Config () {
             image_size = -1,
+            show_album_art = AlbumArtState.ALWAYS,
             autohide = false,
         };
 
@@ -86,6 +104,12 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                 int? image_size = get_prop<int> (config, "image-size", out image_size_found);
                 if (image_size_found && image_size != null) {
                     mpris_config.image_size = image_size;
+                }
+
+                bool show_art_found;
+                string? show_album_art = get_prop<string> (config, "show-album-art", out show_art_found);
+                if (show_art_found && show_album_art != null) {
+                    mpris_config.show_album_art = AlbumArtState.parse (show_album_art);
                 }
 
                 Json.Array ? blacklist = get_prop_array (config, "blacklist");

--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -95,6 +95,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                 });
             });
             album_art.set_pixel_size (mpris_config.image_size);
+            album_art.set_visible (mpris_config.show_album_art == AlbumArtState.ALWAYS);
         }
 
         public void before_destroy () {
@@ -280,6 +281,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                                              get_scale_factor (), snapshot);
                     Graphene.Size size = Graphene.Size ().init (icon_size, icon_size);
                     album_art.set_from_paintable (snapshot.free_to_paintable (size));
+                    album_art.set_visible (mpris_config.show_album_art != AlbumArtState.NEVER);
 
                     // Set background album art
                     background_picture.set_paintable (album_art_texture);
@@ -288,6 +290,8 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                     return;
                 }
             }
+
+            album_art.set_visible (mpris_config.show_album_art == AlbumArtState.ALWAYS);
 
             // Get the app icon
             Icon ? icon = null;


### PR DESCRIPTION
Fixes: #563 

Adds an option to configure whether the album art should be hidden, always visible, or only visible when a valid album art is provided.