### PR TITLE
Add loop-carousel option to mpris.

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -354,6 +354,11 @@ config file to be able to detect config errors
 								 hidden, always visible, or only visible ++
 								 when a valid album art is provided. ++
 					enum: ["right", "left"] ++
+				loop-carousel: ++
+					type: bool ++
+					optional: true ++
+					default: false ++
+					description: Whether to loop through the mpris carousel. ++
 			description: A widget that displays multiple music players. ++
 		*menubar*++
 			type: object ++
@@ -615,7 +620,8 @@ config file to be able to detect config errors
 		"mpris": {
 			"blacklist": ["playerctld"],
 			"autohide": true,
-			"show-album-art": "always"
+			"show-album-art": "always",
+			"loop-carousel": false
 		},
 		"menubar": {
 			"menu#power": {

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -75,7 +75,8 @@
     "mpris": {
       "blacklist": [],
       "autohide": false,
-      "show-album-art": "always"
+      "show-album-art": "always",
+      "loop-carousel": false
     },
     "buttons-grid": {
       "actions": [

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -421,6 +421,11 @@
           "description": "Whether or not the album art should be hidden, always visible, or only visible when a valid album art is provided.",
           "default": "always",
           "enum": ["always", "when-available", "never"]
+        },
+        "loop-carousel": {
+          "type": "boolean",
+          "description": "Whether to loop through the mpris carousel.",
+          "default": "false"
         }
       }
     },


### PR DESCRIPTION
Followup from: https://github.com/ErikReider/SwayNotificationCenter/pull/545

This adds a loop option to mpris so that you you can go past the number of items in the carousel.

Let me know if I did anything wrong adding it to the config or documentation.

Thanks!
