### PR TITLE
Render image-path even if it does not exist (is an icon name)

### DIFF
--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -725,8 +725,7 @@ namespace SwayNotificationCenter {
             if (param.image_data.is_initialized) {
                 Functions.set_image_data (param.image_data, img);
             } else if (param.image_path != null &&
-                       param.image_path != "" &&
-                       img_path_exists) {
+                       param.image_path != "") {
                 Functions.set_image_uri (param.image_path, img,
                                          img_path_exists,
                                          img_path_is_theme_icon);


### PR DESCRIPTION
According to the [notification-spec](https://specifications.freedesktop.org/notification-spec/latest/icons-and-images.html), icon names are supported in the `image-path` hint, but this wasn't being handled correctly in swaync.

An example notification is the following invocation sent by notify-send 0.8.4:
```sh
notify-send -t 800 -e  " " -i audio-volume-low-symbolic -h int:value:20 -h string:synchronous:volume
```

And here's how the dbus call looks:
```sh
% dbus-monitor --session interface=org.freedesktop.Notifications
...
method call time=1751951945.329330 sender=:1.1648 -> destination=:1.1496 serial=10 path=/org/freedesktop/Notifications; interface=org.freedesktop.Notifications; member=Notify
   string "notify-send"
   uint32 0
   string ""
   string " "
   string ""
   array [
   ]
   array [
      dict entry(
         string "image-path"
         variant             string "audio-volume-low-symbolic"
      )
      dict entry(
         string "synchronous"
         variant             string "volume"
      )
      dict entry(
         string "transient"
         variant             boolean true
      )
      dict entry(
         string "urgency"
         variant             byte 1
      )
      dict entry(
         string "value"
         variant             int32 20
      )
      dict entry(
         string "sender-pid"
         variant             int64 1155165
      )
   ]
   int32 800
```
