### PR TITLE
Make notification grouping optional (#376)

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -111,6 +111,11 @@ config file to be able to detect config errors
 	default: true ++
 	description: If control center should use keyboard shortcuts
 
+*grouping* ++
+	type: bool ++
+	default: true ++
+	description: If notifications should be grouped by app name
+
 *image-visibility* ++
 	type: string ++
 	default: always ++
@@ -146,7 +151,7 @@ config file to be able to detect config errors
 	type: bool ++
 	default: true ++
 	description: Display notification timestamps relative to now e.g. \"26 minutes ago\". ++
-		If false, a local iso8601-formatted absolute timestamp is displayed. 
+		If false, a local iso8601-formatted absolute timestamp is displayed.
 
 *control-center-height* ++
 	type: integer ++

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -24,6 +24,7 @@
   "control-center-height": 600,
   "notification-window-width": 500,
   "keyboard-shortcuts": true,
+  "grouping": true,
   "image-visibility": "when-available",
   "transition-time": 200,
   "hide-on-clear": false,

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -421,6 +421,11 @@ namespace SwayNotificationCenter {
          */
         public bool keyboard_shortcuts { get; set; default = true; }
 
+        /**
+         * If notifications should be grouped by app name
+         */
+        public bool grouping { get; set; default = true; }
+
         /** Specifies if the notification image should be shown or not */
         public ImageVisibility image_visibility {
             get;

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -165,6 +165,11 @@
       "description": "If control center should use keyboard shortcuts",
       "default": true
     },
+    "grouping": {
+      "type": "boolean",
+      "description": "If notifications should be grouped by app name",
+      "default": true
+    },
     "image-visibility": {
       "type": "string",
       "description": "The notification image visibility when no icon is available.",

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -703,7 +703,7 @@ namespace SwayNotificationCenter {
             if (param.name_id.length > 0) {
                 noti_groups_name.lookup_extended (param.name_id, null, out group);
             }
-            if (group == null) {
+            if (group == null || ConfigModel.instance.grouping == false) {
                 group = new NotificationGroup (param.name_id, param.display_name);
                 // Collapse other groups on expand
                 group.on_expand_change.connect ((expanded) => {


### PR DESCRIPTION
Notification grouping is cool and looks neat, but it's not very accessible with a keyboard-focused workflow (#522).

This PR adds a "grouping" config entry that defaults to true, but is opt-out as requested in #376.

There is also #392, but that is more of an enhancement request, so this will only close #376.