### PR TITLE
feat: new buttons-per-row property for buttons-grid widget

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -471,6 +471,8 @@ config file to be able to detect config errors
 			type: object ++
 			css class: widget-buttons (access buttons with >flowbox>flowboxchild>button) ++
 			properties: ++
+				buttons-per-row: ++
+				    type: number ++
 				actions: ++
 					type: array ++
 					Default values: [] ++

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -79,6 +79,7 @@
       "loop-carousel": false
     },
     "buttons-grid": {
+      "buttons-per-row": 7,
       "actions": [
         {
           "label": "直",

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -434,6 +434,10 @@
       "description": "A widget to add a grid of buttons that execute shell commands",
       "additionalProperties": false,
       "properties": {
+        "buttons-per-row": {
+          "type": "number",
+          "description": "How many buttons should be shown in a buttons-grid row"
+        },
         "actions": {
           "type": "array",
           "description": "A list of actions containing a label and a command",

--- a/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
+++ b/src/controlCenter/widgets/buttonsGrid/buttonsGrid.vala
@@ -10,6 +10,8 @@ namespace SwayNotificationCenter.Widgets {
         }
 
         Action[] actions;
+        // 7 is the default Gtk.FlowBox.max_children_per_line
+        int buttons_per_row = 7;
         List<ToggleButton> toggle_buttons;
 
         public ButtonsGrid (string suffix, SwayncDaemon swaync_daemon, NotiDaemon noti_daemon) {
@@ -19,9 +21,14 @@ namespace SwayNotificationCenter.Widgets {
             if (config != null) {
                 Json.Array a = get_prop_array (config, "actions");
                 if (a != null) actions = parse_actions (a);
+
+                bool bpr_found = false;
+                int bpr = get_prop<int> (config, "buttons-per-row", out bpr_found);
+                if (bpr_found) buttons_per_row = bpr;
             }
 
             Gtk.FlowBox container = new Gtk.FlowBox ();
+            container.set_max_children_per_line (buttons_per_row);
             container.set_selection_mode (Gtk.SelectionMode.NONE);
             container.set_hexpand (true);
             append (container);


### PR DESCRIPTION
This change adds a new property `buttons-per-grid` to the `buttons-grid` widget configuration.

This was made to avoid having extra space on the right side of the `buttons-grid` widget, caused by not setting the `Gtk.FlowBox` `max-children-per-line` property, which defaults to 7.

This keeps the default of 7 and optionally allows users to override it to better fit this widget to specific use-cases.

Following are screenshots of the result.

Before:

![image](https://github.com/user-attachments/assets/9cdf2b97-1e3f-42c5-976e-93dc71096ceb)

After, with value set to 5:

![image](https://github.com/user-attachments/assets/b99072a7-ee27-481b-a940-d5ecb92dcef8)
