### PR TITLE
Truncate Per App Volume Labels if exceeding a certain (hardcoded, but could also be configurable) length.

### DIFF
--- a/src/controlCenter/widgets/volume/sinkInputRow.vala
+++ b/src/controlCenter/widgets/volume/sinkInputRow.vala
@@ -56,7 +56,11 @@ namespace SwayNotificationCenter.Widgets {
             }
 
             if (show_per_app_label) {
-                label.set_text (this.sink_input.name);
+                if (this.sink_input.name.length >=10) {
+                    label.set_text(this.sink_input.name.substring(0, 7).concat("...")); 
+                } else {
+                    label.set_text (this.sink_input.name);
+                }
             }
 
             scale.set_value (sink_input.volume);


### PR DESCRIPTION
As title says.
It can be paired with the css property min-width while styiling to also adjust shorter names and align volume controllers of any name.

Before:
<img width="323" height="90" alt="image" src="https://github.com/user-attachments/assets/bd5d7f08-d167-4bc6-8ef3-48d9466c2570" />

After:
<img width="341" height="100" alt="image" src="https://github.com/user-attachments/assets/11927269-eb18-4a1f-bd99-272e08749152" />
(For context i set 100px as the min width to align shorter labels as well)
<img width="232" height="68" alt="image" src="https://github.com/user-attachments/assets/a9bc0bd9-3302-4b1f-80cc-7e69c4c10848" />

The implementation of max-width and overflow css properties would make this patch not necessary to achieve the same result.