### PR TITLE
Fixed the missing "," mistake on line 367

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Config properties:
     // that exact summary and body
     "example-script": {
       "exec": "/path/to/myRickRollScript.sh",
-      "app-name": "Spotify"
+      "app-name": "Spotify",
       "summary": "Never Gonna Give You Up",
       "body": "Rick Astley - Whenever You Need Somebody"
     }


### PR DESCRIPTION
Fixed the missing "," mistake on README.md because it is annoying for me
<img width="822" height="401" alt="screenshot-20250713-145620" src="https://github.com/user-attachments/assets/396f52b5-c602-4d85-8668-8c971e8c523c" />
