### PR TITLE
Add `ignore-gtk-theme` config option 

### DIFF
--- a/man/swaync.5.scd
+++ b/man/swaync.5.scd
@@ -9,6 +9,12 @@ swaync - Configuration file
 Using a text editor with a JSON language server is recommended when editing the
 config file to be able to detect config errors
 
+*ignore-gtk-theme* ++
+	type: bool ++
+	default: true ++
+	description: Unsets the GTK_THEME environment variable, fixing a lot of ++
+				 issues with GTK themes ruining the users custom CSS themes.
+
 *positionX* ++
 	type: string ++
 	default: right ++

--- a/src/config.json.in
+++ b/src/config.json.in
@@ -1,5 +1,6 @@
 {
   "$schema": @JSONPATH@,
+  "ignore-gtk-theme": true,
   "positionX": "right",
   "positionY": "top",
   "layer": "overlay",

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -316,7 +316,7 @@ namespace SwayNotificationCenter {
 
         /** Get the static singleton and reload the config */
         public static unowned ConfigModel init (string ? path) {
-            _path = Functions.get_config_path (path);
+            _path = path;
             reload_config ();
             return _instance;
         }
@@ -358,10 +358,15 @@ namespace SwayNotificationCenter {
             _path = path;
             debug (_instance.to_string ());
 
-            app.config_reload (previous_config, m);
+            if (app != null) {
+                app.config_reload (previous_config, m);
+            }
         }
 
         /* Properties */
+
+        /** Unsets the GTK_THEME env variable when true */
+        public bool ignore_gtk_theme { get; set; default = true; }
 
         /** The notifications and controlcenters horizontal alignment */
         public PositionX positionX { // vala-lint=naming-convention

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -8,6 +8,11 @@
       "type": "string",
       "description": "Pointer to the schema against which this document should be validated."
     },
+    "ignore-gtk-theme": {
+      "type": "boolean",
+      "description": "Unsets the GTK_THEME environment variable, fixing a lot of issues with GTK themes ruining the users custom CSS themes.",
+      "default": true
+    },
     "positionX": {
       "type": "string",
       "description": "Horizontal position of control center and notification window",

--- a/src/main.vala
+++ b/src/main.vala
@@ -39,7 +39,6 @@ namespace SwayNotificationCenter {
                 return;
             }
             activated = true;
-            ConfigModel.init (config_path);
             Functions.load_css (style_path);
 
             hold ();
@@ -74,9 +73,6 @@ namespace SwayNotificationCenter {
         }
 
         public static int main (string[] args) {
-            Gtk.init ();
-            Adw.init ();
-
             if (args.length > 0) {
                 for (uint i = 1; i < args.length; i++) {
                     string arg = args[i];
@@ -106,6 +102,16 @@ namespace SwayNotificationCenter {
                     }
                 }
             }
+
+            ConfigModel.init (config_path);
+
+            // Fixes custom themes messing with the default/custom CSS styling
+            if (ConfigModel.instance.ignore_gtk_theme) {
+                Environment.unset_variable ("GTK_THEME");
+            }
+
+            Gtk.init ();
+            Adw.init ();
 
             Functions.init ();
             self_settings = new Settings ("org.erikreider.swaync");


### PR DESCRIPTION
This fixes GTK 4 themes messing with / ruining the users custom CSS styling / theme