### PR TITLE
Fixed missing text color on the notification action button

### DIFF
--- a/data/style/style.scss
+++ b/data/style/style.scss
@@ -220,6 +220,7 @@ $notification-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3),
 
         & > button {
           border-radius: $border-radius;
+          color: var(--text-color);
         }
       }
     }


### PR DESCRIPTION
I noticed that the `--text-color` var is not applied to the notification action buttons. Hence, this PR fixes this issue.

Before:
<img width="500" height="192" alt="image" src="https://github.com/user-attachments/assets/fc86b76d-c3f9-4b4d-8257-21fc15272111" />

After:
<img width="501" height="191" alt="image" src="https://github.com/user-attachments/assets/5e9934e4-eee5-43b2-b4f0-4d6cbeb24224" />
