### PR TITLE
fix: Add json schema for "autohide" and "blacklist" in "mpris"

### DIFF
--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -468,6 +468,19 @@
           "default": "always",
           "enum": ["always", "when-available", "never"]
         },
+        "autohide": {
+          "type": "boolean",
+          "description": "Whether to hide the widget when the player has no metadata.",
+          "default": false
+        },
+        "blacklist": {
+          "type": "array",
+          "description": "Audio sources for the mpris widget to ignore.",
+          "items": {
+            "type": "string",
+            "description": "Audio source/app name. Regex alowed."
+          }
+        },
         "loop-carousel": {
           "type": "boolean",
           "description": "Whether to loop through the mpris carousel.",


### PR DESCRIPTION
#390 and #533 missed adding the new options to the schema