### PR TITLE
fix: Search icon by process name if icon is missing 

### DIFF
--- a/src/controlCenter/widgets/volume/sinkInputRow.vala
+++ b/src/controlCenter/widgets/volume/sinkInputRow.vala
@@ -52,16 +52,16 @@ namespace SwayNotificationCenter.Widgets {
 
             if (show_per_app_icon) {
                 string icon_name;
-                if (sink_input.application_icon_name != null) { 
+                if (sink_input.application_icon_name != null) {
                     icon_name = sink_input.application_icon_name;
                 } else {
                     icon_name = sink_input.application_binary;
                 }
-                var theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
-                if (theme.has_icon(icon_name)) {
-                    icon.set_from_icon_name(icon_name);
+                var theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
+                if (theme.has_icon (icon_name)) {
+                    icon.set_from_icon_name (icon_name);
                 } else {
-                    icon.set_from_icon_name("application-x-executable");
+                    icon.set_from_icon_name ("application-x-executable");
                 }
             }
 


### PR DESCRIPTION
This fixes: #344 
Some apps dont provide the icon so this makes it fallback to searching for the icon by process name