### PR TITLE
Fix `transition` typo

### DIFF
--- a/data/style/style.scss
+++ b/data/style/style.scss
@@ -27,8 +27,12 @@
   --font-size-body: 15px;
   --font-size-summary: 16px;
 
+  /* Deprecated variables (because of their typos). Keeeping them around for backwards compatibility. */
   --hover-tranistion: background 0.15s ease-in-out;
   --group-collapse-tranistion: opacity 400ms ease-in-out;
+
+  --hover-transition: var(--hover-tranistion);
+  --group-collapse-transition: var(--group-collapse-tranistion);
 }
 
 /* Fallback for older CSS themes */


### PR DESCRIPTION
Fixing a typo in these variable names.

~This is a breaking change, and so I'm open to deprecating the older variable name as a more flexible change instead.~ See discussion below for the resolution.