### PR TITLE
Changed the CSS name of the transparent windows fixing GTK CSS overrides

### DIFF
--- a/data/style/style.scss
+++ b/data/style/style.scss
@@ -40,6 +40,10 @@
 
 $margin: 8px;
 
+notificationwindow, blankwindow, blankwindow {
+  background: transparent;
+}
+
 .close-button {
   /* The notification Close Button */
   background: var(--noti-close-bg);

--- a/src/blankWindow/blankWindow.vala
+++ b/src/blankWindow/blankWindow.vala
@@ -7,6 +7,7 @@ namespace SwayNotificationCenter {
         private bool blank_window_in = false;
 
         public BlankWindow (Gdk.Monitor monitor) {
+            Object (css_name: "blankwindow");
             this.monitor = monitor;
 
             blank_window_gesture = new Gtk.GestureClick ();

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -24,6 +24,7 @@ namespace SwayNotificationCenter {
         private string ? monitor_name = null;
 
         public ControlCenter (SwayncDaemon swaync_daemon, NotiDaemon noti_daemon) {
+            Object (css_name: "blankwindow");
             this.swaync_daemon = swaync_daemon;
             this.noti_daemon = noti_daemon;
 

--- a/src/notificationWindow/notificationWindow.vala
+++ b/src/notificationWindow/notificationWindow.vala
@@ -43,6 +43,7 @@ namespace SwayNotificationCenter {
         private const int MAX_HEIGHT = 600;
 
         private NotificationWindow () {
+            Object (css_name: "notificationwindow");
             if (swaync_daemon.use_layer_shell) {
                 if (!GtkLayerShell.is_supported ()) {
                     stderr.printf ("GTKLAYERSHELL IS NOT SUPPORTED!\n");


### PR DESCRIPTION
This should completely fix #584, even if the CSS priority is set to "application"