### PR TITLE
Update waybar docs to deal with edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,11 +439,11 @@ Waybar css file
 }
 ```
 
-Alternatively, the number of notifications can be shown by adding `{}` anywhere in the `format` field in the Waybar config
+Alternatively, the number of notifications can be shown by adding `{0}` anywhere in the `format` field in the Waybar config
 
 ```jsonc
   "custom/notification": {
-    "format": "{} {icon}",
+    "format": "{0} {icon}",
     // ...
   },
 ```


### PR DESCRIPTION
In waybar formatting, adding "{}" only works when adding it before the icon. It breaks when adding it after the icon. This change fixes the snippet in our README, so that if someone copies our snippet, it will be easier to make changes.

My guess is that it has something to do with how the formatting library waybar uses under the hood interprets this. 