### PR TITLE
Consolidate --noti-bg and --noti-bg-alpha in a single variable

### DIFF
--- a/data/style/style.scss
+++ b/data/style/style.scss
@@ -4,6 +4,7 @@
   --noti-border-color: rgba(255, 255, 255, 0.15);
   --noti-bg: 48, 48, 48;
   --noti-bg-alpha: 0.8;
+  --noti-bg-normal: rgba(var(--noti-bg), var(--noti-bg-alpha));
   --noti-bg-darker: rgb(38, 38, 38);
   --noti-bg-hover: rgb(56, 56, 56);
   --noti-bg-focus: rgba(68, 68, 68, 0.6);
@@ -33,6 +34,11 @@
 
   --hover-transition: var(--hover-tranistion);
   --group-collapse-transition: var(--group-collapse-tranistion);
+}
+
+@function gtk-alpha($color, $alpha) {
+  /* GTK's alpha() emulated */
+  @return unquote("alpha(#{$color}, #{$alpha})");
 }
 
 /* Fallback for older CSS themes */
@@ -85,7 +91,7 @@ notificationwindow, blankwindow, blankwindow {
       border: var(--border);
       padding: 0;
       transition: var(--hover-tranistion);
-      background: rgba(var(--noti-bg), var(--noti-bg-alpha));
+      background: var(--noti-bg-normal);
 
       &.low {
         /* Low Priority Notification */
@@ -205,7 +211,7 @@ notificationwindow, blankwindow, blankwindow {
 
             .inline-reply-button {
               margin-left: 4px;
-              background: rgba(var(--noti-bg), var(--noti-bg-alpha));
+              background: var(--noti-bg-normal);
               border: var(--border);
               border-radius: var(--border-radius);
               color: var(--text-color);
@@ -304,7 +310,7 @@ notificationwindow, blankwindow, blankwindow {
 
     .notification-row {
       .notification {
-        background-color: rgba(var(--noti-bg), 1);
+        background-color: gtk-alpha(var(--noti-bg-normal), 1);
       }
 
       &:not(:last-child) {


### PR DESCRIPTION
I prefer having a minimal CSS, and having it synced to GTK's colorscheme, so I use GTK's CSS variables: `@window_bg_color`, `@window_fg_color`, etc. These colors are in `rgb()` or a similar format, which makes it not possible to set `--noti-bg` to.

It's also a matter of inconsistency; all colors are in `rgb()` format, except `--noti-bg`. It is simply a set of three comma-separated values.

Digging through the scss file and doing my due research, I created a new variable, `--noti-bg-normal`, which used the color equivalent to `rgba(var(--noti-bg), var(--noti-bg-alpha))`. Used it wherever applicable.

There was also this one instance where the alpha value was constant. I decided to use GTK's `alpha()`, but found out that it is already used by SASS. Thusly, I had to create a function which generated the required `alpha()` code upon compilation.

I guess its safe to say that `--noti-bg` and `--noti-bg-alpha` can be marked as deprecated.