### PR TITLE
README: added Void installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ https://github.com/user-attachments/assets/5c054ac3-90bb-483e-a8f2-5af191805f04
      * [Debian](#debian)
      * [Guix](#guix)
      * [rde](#rde)
+     * [Void](#void)
      * [Other](#other)
   * [Sway Usage](#sway-usage)
   * [Run](#run)
@@ -187,6 +188,12 @@ But we recommend to use [Guix Home](https://guix.gnu.org/manual/devel/en/html_no
 
 ;; Include the following code into the list of your rde features:
 (feature-swaynotificationcenter)
+```
+
+### Void
+
+```zsh
+sudo xbps-install -S SwayNotificationCenter
 ```
 
 ### Other


### PR DESCRIPTION
Added installation guide for [Void](https://voidlinux.org/packages/?arch=x86_64&q=SwayNotificationCenter) Linux in the README file.