### PR TITLE
Invoke default action when `swaync-client --action` is called without an index

### DIFF
--- a/man/swaync-client.1.scd
+++ b/man/swaync-client.1.scd
@@ -74,7 +74,8 @@ swaync-client - Client executable
 	Closes all notifications
 
 *-a, --action [ACTION_INDEX]*
-	Invokes the action [ACTION_INDEX] (or 0) of the latest notification
+	Invokes the default action, or action [ACTION_INDEX], of the latest
+	notification
 
 *-sw, --skip-wait*
 	Doesn't wait when swaync hasn't been started

--- a/man/swaync-client.1.scd
+++ b/man/swaync-client.1.scd
@@ -74,8 +74,10 @@ swaync-client - Client executable
 	Closes all notifications
 
 *-a, --action [ACTION_INDEX]*
-	Invokes the default action, or action [ACTION_INDEX], of the latest
-	notification
+	Invokes the action [ACTION_INDEX] (or 0) of the latest notification
+
+*-ad, --action-default*
+	Invokes the default action of the latest notification
 
 *-sw, --skip-wait*
 	Doesn't wait when swaync hasn't been started

--- a/src/client.vala
+++ b/src/client.vala
@@ -80,7 +80,9 @@ private void print_help (string[] args) {
     print ("      \t --close-latest \t\t Closes latest notification\n");
     print ("  -C, \t --close-all \t\t\t Closes all notifications\n");
     print ("  -a, \t --action [ACTION_INDEX]\t " +
-           "Invokes the default action, or action [ACTION_INDEX], of the latest notification\n");
+           "Invokes the action [ACTION_INDEX] (or 0) of the latest notification\n");
+    print ("  -ad,\t --action-default \t\t " +
+           "Invokes the default action of the latest notification\n");
     print ("  -sw, \t --skip-wait \t\t\t Doesn't wait when swaync hasn't been started\n");
     print ("  -s, \t --subscribe \t\t\t Subscribe to notification add and close events\n");
     print ("  -swb,  --subscribe-waybar \t\t Subscribe to notification add and close events "
@@ -211,13 +213,16 @@ public int command_line (ref string[] args, bool skip_wait) {
                 break;
             case "--action":
             case "-a":
+                int action_index = 0;
                 if (args.length >= 2) {
                     used_args++;
-                    int action_index = int.parse (args[1]);
-                    cc_daemon.latest_invoke_action ((uint32) action_index);
-                } else {
-                    cc_daemon.latest_invoke_default_action ();
+                    action_index = int.parse (args[1]);
                 }
+                cc_daemon.latest_invoke_action ((uint32) action_index);
+                break;
+            case "--action-default":
+            case "-ad":
+                cc_daemon.latest_invoke_default_action ();
                 break;
             case "--get-inhibited":
             case "-I":

--- a/src/client.vala
+++ b/src/client.vala
@@ -80,7 +80,7 @@ private void print_help (string[] args) {
     print ("      \t --close-latest \t\t Closes latest notification\n");
     print ("  -C, \t --close-all \t\t\t Closes all notifications\n");
     print ("  -a, \t --action [ACTION_INDEX]\t " +
-           "Invokes the action [ACTION_INDEX] of the latest notification\n");
+           "Invokes the default action, or action [ACTION_INDEX], of the latest notification\n");
     print ("  -sw, \t --skip-wait \t\t\t Doesn't wait when swaync hasn't been started\n");
     print ("  -s, \t --subscribe \t\t\t Subscribe to notification add and close events\n");
     print ("  -swb,  --subscribe-waybar \t\t Subscribe to notification add and close events "

--- a/src/client.vala
+++ b/src/client.vala
@@ -33,6 +33,8 @@ interface CcDaemon : Object {
 
     public abstract void latest_invoke_action (uint32 action_index) throws DBusError, IOError;
 
+    public abstract void latest_invoke_default_action () throws DBusError, IOError;
+
     public abstract bool set_cc_monitor (string monitor) throws DBusError, IOError;
     public abstract bool set_noti_window_monitor (string monitor) throws DBusError, IOError;
 
@@ -209,12 +211,13 @@ public int command_line (ref string[] args, bool skip_wait) {
                 break;
             case "--action":
             case "-a":
-                int action_index = 0;
                 if (args.length >= 2) {
                     used_args++;
-                    action_index = int.parse (args[1]);
+                    int action_index = int.parse (args[1]);
+                    cc_daemon.latest_invoke_action ((uint32) action_index);
+                } else {
+                    cc_daemon.latest_invoke_default_action ();
                 }
-                cc_daemon.latest_invoke_action ((uint32) action_index);
                 break;
             case "--get-inhibited":
             case "-I":

--- a/src/notiDaemon/notiDaemon.vala
+++ b/src/notiDaemon/notiDaemon.vala
@@ -122,6 +122,11 @@ namespace SwayNotificationCenter {
             floating_notifications.latest_notification_action (action_index);
         }
 
+        /** Activates the default action of the latest notification */
+        internal void invoke_latest_floating_default_action () {
+            floating_notifications.latest_notification_default_action ();
+        }
+
         /*
          * D-Bus Specification
          * https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html

--- a/src/notificationWindow/notificationWindow.vala
+++ b/src/notificationWindow/notificationWindow.vala
@@ -357,6 +357,17 @@ namespace SwayNotificationCenter {
             noti.click_alt_action (action);
         }
 
+        public void latest_notification_default_action () {
+            unowned AnimatedListItem ?item = list.get_first_item ();
+            if (item == null || !(item.child is Notification)) {
+                warn_if_reached ();
+                return;
+            }
+
+            Notification noti = (Notification) item.child;
+            noti.click_default_action ();
+        }
+
         public void set_monitor (Gdk.Monitor ?monitor) {
             debug ("Setting monitor for Floating Notifications: %s",
                    Functions.monitor_to_string (monitor) ?? "Monitor Picked by Compositor");

--- a/src/swayncDaemon/swayncDaemon.vala
+++ b/src/swayncDaemon/swayncDaemon.vala
@@ -154,6 +154,12 @@ namespace SwayNotificationCenter {
             noti_daemon.invoke_latest_floating_action (action_index);
         }
 
+        /** Activates the default action of the latest floating notification */
+        public inline void latest_invoke_default_action ()
+        throws DBusError, IOError {
+            noti_daemon.invoke_latest_floating_default_action ();
+        }
+
         /**
          * Adds an inhibitor with the Application ID
          * (ex: "org.erikreider.swaysettings", "swayidle", etc...).


### PR DESCRIPTION
Previously, `--action` without an index would call `click_alt_action(0)`, which silently did nothing if the alt actions box wasn't visible. Now it invokes the notification's default action instead, matching user expectations. When an index is provided, the existing alt action behavior is preserved. Please note, that this is a breaking change: users might need to change their scripts.