### PR TITLE
Use meson config_path as fallback instead of hardcoded /usr/local

### DIFF
--- a/src/constants.vala.in
+++ b/src/constants.vala.in
@@ -1,5 +1,6 @@
 public class Constants {
     public const string VERSION = @VERSION@;
     public const string VERSIONNUM = @VERSION_NUM@;
+    public const string CONFIGPATH = @CONFIG_PATH@;
     public const uint ANIMATION_DURATION = 400;
 }

--- a/src/functions.vala
+++ b/src/functions.vala
@@ -145,7 +145,8 @@ namespace SwayNotificationCenter {
                                           path, "swaync/style.css");
             }
             // Fallback location. Specified in postinstall.py. Mostly for Debian
-            paths += "/usr/local/etc/xdg/swaync/style.css";
+            paths += Path.build_path (Path.DIR_SEPARATOR.to_string (),
+                                      Constants.CONFIGPATH, "style.css");
 
             info ("Looking for CSS file in these directories:\n\t- %s",
                   string.joinv ("\n\t- ", paths));
@@ -187,7 +188,8 @@ namespace SwayNotificationCenter {
                                           path, "swaync/config.json");
             }
             // Fallback location. Specified in postinstall.py. Mostly for Debian
-            paths += "/usr/local/etc/xdg/swaync/config.json";
+            paths += Path.build_path (Path.DIR_SEPARATOR.to_string (),
+                                      Constants.CONFIGPATH, "config.json");
 
             info ("Looking for config file in these directories:\n\t- %s",
                   string.joinv ("\n\t- ", paths));

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ version = 'swaync @0@'.format(version)
 const_config_data = configuration_data()
 const_config_data.set_quoted('VERSION', version)
 const_config_data.set_quoted('VERSION_NUM', meson.project_version())
+const_config_data.set_quoted('CONFIG_PATH', join_paths(get_option('prefix'), config_path))
 constants = configure_file(
   input : 'constants.vala.in',
   output : 'constants.vala',


### PR DESCRIPTION
Fixes: #726

The hardcoded fallback path `/usr/local/etc/xdg/swaync/` in `src/functions.vala` breaks installations with custom prefixes (e.g. `~/.local`, FreeBSD's `/usr/local`, NetBSD's `/usr/pkg`).

This PR injects the meson `config_path` (resolved at build time) into the Vala source as a compile-time constant, replacing the hardcoded fallback in both `get_style_path()` and `get_config_path()`.

Related: #4, #167, #168