### PR TITLE
fix(backlight): recreate FileMonitor after close

### DIFF
--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -347,24 +347,24 @@ namespace SwayNotificationCenter {
             switch (this) {
                 default :
                 return "enabled";
-                case MUTED:
+                case MUTED :
                     return "muted";
-                case IGNORED:
+                case IGNORED :
                     return "ignored";
-                case TRANSIENT:
+                case TRANSIENT :
                     return "transient";
             }
         }
 
         public static NotificationStatusEnum from_value (string value) {
             switch (value) {
-                default:
-                    return ENABLED;
-                case "muted":
+                default :
+                return ENABLED;
+                case "muted" :
                     return MUTED;
-                case "ignored":
+                case "ignored" :
                     return IGNORED;
-                case "transient":
+                case "transient" :
                     return TRANSIENT;
             }
         }
@@ -382,9 +382,9 @@ namespace SwayNotificationCenter {
 
         public string to_string () {
             switch (this) {
-                case LOW:
+                case LOW :
                     return "Low";
-                case NORMAL:
+                case NORMAL :
                     return "Normal";
                 case CRITICAL:
                     return "Critical";

--- a/src/controlCenter/widgets/backlight/backlightUtil.vala
+++ b/src/controlCenter/widgets/backlight/backlightUtil.vala
@@ -66,17 +66,24 @@ namespace SwayNotificationCenter.Widgets {
         }
 
         private void connect_monitor () {
-            if (monitor != null) {
-                // connect monitor to monitor changes
-                monitor.changed.connect ((src, dest, event) => {
-                    get_brightness ();
-                });
+            if (monitor == null) {
+                try {
+                    monitor = fd.monitor (FileMonitorFlags.NONE, null);
+                } catch (Error e) {
+                    critical ("Error %s\n", e.message);
+                    return;
+                }
             }
+            // connect monitor to monitor changes
+            monitor.changed.connect ((src, dest, event) => {
+                get_brightness ();
+            });
         }
 
         public void close () {
             if (monitor != null) {
                 monitor.cancel ();
+                monitor = null;
             }
         }
 


### PR DESCRIPTION
## Summary
- `FileMonitor` is single-use: once `monitor.cancel()` runs in `close()` the same instance never emits `changed` again.
- Monitor was created only in the constructor, so after the control center closed the first time, reopening left the slider stale.
- Null `monitor` in `close()` and (re)create it lazily in `connect_monitor()` so every `start()` gets a live monitor.

Fixes #728