### PR TITLE
Update all `actions/checkout` uses in CI to latest v4

### DIFF
--- a/.github/workflows/PKGBUILD-build.yml
+++ b/.github/workflows/PKGBUILD-build.yml
@@ -33,7 +33,7 @@ jobs:
           printf 'builduser ALL=(ALL) ALL\n' | tee -a /etc/sudoers
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: swaync

--- a/.github/workflows/fedora-build.yml
+++ b/.github/workflows/fedora-build.yml
@@ -26,7 +26,7 @@ jobs:
 
       # It is necessary to checkout into sub-directory, because of some weird ownership problems cause by using containers
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: swaync

--- a/.github/workflows/fedora-copr.yml
+++ b/.github/workflows/fedora-copr.yml
@@ -34,7 +34,7 @@ jobs:
 
       # It is necessary to checkout into sub-directory, because of some weird ownership problems cause by using containers
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: swaync

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
   vala-linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: elementary/actions/vala-lint@master
       with:
         dir: src/
@@ -35,7 +35,7 @@ jobs:
             uncrustify
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: swaync
@@ -55,7 +55,7 @@ jobs:
             rpmlint rpkg
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: swaync

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -27,7 +27,7 @@ jobs:
           apt install -y $PACKAGES
 
       - name: Check out sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Meson configure
         run: meson build


### PR DESCRIPTION
Update all `actions/checkout` uses in CI to latest v6