### PR TITLE
feat: add compositor-level background blur via ext-background-effect-v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,31 @@ The main config file is located in `/etc/xdg/swaync/config.json`. Copy it over
 to your `.config/swaync/` folder to customize without needing root access.
 See `swaync(5)` man page for more information
 
+### Background Blur
+
+SwayNotificationCenter can blur the background behind the control center and
+notification popups using the `ext-background-effect-v1` Wayland protocol.
+This requires compositor support (e.g. niri, KDE Plasma 6.3+).
+
+To enable it, set `"background-blur": true` in your `config.json` and make sure
+the CSS backgrounds have some transparency so the blur is visible. For example:
+
+```css
+.control-center {
+  background: rgba(30, 30, 30, 0.5);
+}
+.floating-notifications .notification {
+  background: rgba(28, 28, 30, 0.45);
+}
+```
+
+The blur region shape derives its `border-radius` automatically by reading the
+`--border-radius` CSS variable. If your custom style overrides the border radius
+via a variable (e.g. `--border-radius: 14px`), the blur corners will match. If
+you set `border-radius` directly on a class without an accompanying
+`--border-radius` variable, the blur region will be rectangular (no rounding).
+No separate configuration is needed for corner rounding.
+
 To reload the config, you'll need to run `swaync-client --reload-config`
 
 The main CSS style file is located in `/etc/xdg/swaync/style.css`. Copy it over

--- a/protocols/ext-background-effect-v1.deps
+++ b/protocols/ext-background-effect-v1.deps
@@ -1,0 +1,1 @@
+wayland-client

--- a/protocols/ext-background-effect-v1.vapi
+++ b/protocols/ext-background-effect-v1.vapi
@@ -1,0 +1,50 @@
+namespace Ext.BackgroundEffect {
+    [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "struct ext_background_effect_manager_v1", cprefix = "ext_background_effect_manager_v1_")]
+    public class Manager : Wl.Proxy {
+        [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "ext_background_effect_manager_v1_interface")]
+        public static Wl.Interface iface;
+        public void set_user_data (void * user_data);
+        public void * get_user_data ();
+        public uint32 get_version ();
+
+        public void destroy ();
+        public int add_listener (ManagerListener listener, void * data);
+        public Surface * get_background_effect (Wl.Surface surface);
+    }
+
+    [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "enum ext_background_effect_manager_v1_error", cprefix = "EXT_BACKGROUND_EFFECT_MANAGER_V1_ERROR_", has_type_id = false)]
+    public enum ManagerError {
+        BACKGROUND_EFFECT_EXISTS = 0,
+    }
+
+    [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "enum ext_background_effect_manager_v1_capability", cprefix = "EXT_BACKGROUND_EFFECT_MANAGER_V1_CAPABILITY_", has_type_id = false)]
+    [Flags]
+    public enum Capability {
+        BLUR = 1,
+    }
+
+    [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "struct ext_background_effect_manager_v1_listener", has_type_id = false)]
+    public struct ManagerListener {
+        public ManagerListenerCapabilities capabilities;
+    }
+
+    [CCode (has_target = false, has_typedef = false)]
+    public delegate void ManagerListenerCapabilities (void * data, Manager manager, uint32 flags);
+
+    [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "struct ext_background_effect_surface_v1", cprefix = "ext_background_effect_surface_v1_")]
+    public class Surface : Wl.Proxy {
+        [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "ext_background_effect_surface_v1_interface")]
+        public static Wl.Interface iface;
+        public void set_user_data (void * user_data);
+        public void * get_user_data ();
+        public uint32 get_version ();
+
+        public void destroy ();
+        public void set_blur_region (Wl.Region ? region);
+    }
+
+    [CCode (cheader_filename = "ext-background-effect-v1-client-protocol.h", cname = "enum ext_background_effect_surface_v1_error", cprefix = "EXT_BACKGROUND_EFFECT_SURFACE_V1_ERROR_", has_type_id = false)]
+    public enum SurfaceError {
+        SURFACE_DESTROYED = 0,
+    }
+}

--- a/protocols/ext-background-effect-v1.xml
+++ b/protocols/ext-background-effect-v1.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_background_effect_v1">
+  <copyright>
+    Copyright (C) 2015 Martin Gräßlin
+    Copyright (C) 2015 Marco Martin
+    Copyright (C) 2020 Vlad Zahorodnii
+    Copyright (C) 2024 Xaver Hugl
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="background effect protocol">
+    This protocol provides a way to improve visuals of translucent surfaces
+    by applying effects like blur to the background behind them.
+
+    The capabilities are send when the global is bound, and every time they
+    change. Note that when the capability goes away, the corresponding effect
+    is no longer applied by the compositor, even if it was set before.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_background_effect_manager_v1" version="1">
+    <description summary="background effect factory">
+      This protocol provides a way to improve visuals of translucent surfaces
+      by applying effects like blur to the background behind them.
+    </description>
+
+    <enum name="error">
+      <entry name="background_effect_exists" value="0"
+             summary="the surface already has a background effect object"/>
+    </enum>
+
+    <enum name="capability" bitfield="true">
+      <description summary="compositor capabilities">
+        These flags indicate which background effect features the compositor
+        supports.
+      </description>
+      <entry name="blur" value="1" summary="the compositor supports applying blur"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="capabilities of the compositor">
+        Advertises the capabilities of the compositor.
+      </description>
+      <arg name="flags" type="uint" enum="capability"
+           summary="capabilities of the compositor"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the background effect manager">
+        Informs the server that the client will no longer be using this
+        protocol object. Existing objects created by this object are not
+        affected.
+      </description>
+    </request>
+
+    <request name="get_background_effect">
+      <description summary="get a background effects object">
+        Instantiate an interface extension for the given wl_surface to add
+        effects like blur for the background behind it.
+
+        If the given wl_surface already has a ext_background_effect_surface_v1
+        object associated, the background_effect_exists protocol error will be
+        raised.
+      </description>
+      <arg name="id" type="new_id" interface="ext_background_effect_surface_v1"
+           summary="the new ext_background_effect_surface_v1 object"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="ext_background_effect_surface_v1" version="1">
+    <description summary="background effects for a surface">
+      The background effect object provides a way to specify a region behind a
+      surface that should have background effects like blur applied.
+
+      If the wl_surface associated with the ext_background_effect_surface_v1
+      object has been destroyed, this object becomes inert.
+    </description>
+
+    <enum name="error">
+      <entry name="surface_destroyed" value="0"
+             summary="the associated surface has been destroyed"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the blur object">
+        Informs the server that the client will no longer be using this
+        protocol object. The effect regions will be removed on the next
+        commit.
+      </description>
+    </request>
+
+    <request name="set_blur_region">
+      <description summary="set blur region">
+        This request sets the region of the surface that will have its
+        background blurred.
+
+        The blur region is specified in the surface-local coordinates, and
+        clipped by the compositor to the surface size.
+
+        The initial value for the blur region is empty. Setting the pending
+        blur region has copy semantics, and the wl_region object can be
+        destroyed immediately. A NULL wl_region removes the effect.
+
+        The blur region is double-buffered state, and will be applied on the
+        next wl_surface.commit.
+
+        The blur algorithm is subject to compositor policies.
+
+        If the associated surface has been destroyed, the surface_destroyed
+        error will be raised.
+      </description>
+      <arg name="region" type="object" interface="wl_region"
+           summary="blur region of the surface" allow-null="true"/>
+    </request>
+  </interface>
+</protocol>

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -1,32 +1,51 @@
 dep_scanner = dependency('wayland-scanner', native: true)
 prog_scanner = find_program(dep_scanner.get_variable(pkgconfig: 'wayland_scanner'))
 
-protocol_file = files(
-  'xdg-activation-v1.xml',
-)
-
-protocol_sources = []
-protocol_sources += custom_target(
-  'xdg-activation-v1-client-protocol.h',
-  command: [prog_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
-  input: protocol_file,
-  output: 'xdg-activation-v1-client-protocol.h',
-)
-
 output_type = 'private-code'
 if dep_scanner.version().version_compare('< 1.14.91')
   output_type = 'code'
 endif
+
+protocol_sources = []
+
+# xdg-activation-v1
+xdg_activation_file = files('xdg-activation-v1.xml')
+
+protocol_sources += custom_target(
+  'xdg-activation-v1-client-protocol.h',
+  command: [prog_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+  input: xdg_activation_file,
+  output: 'xdg-activation-v1-client-protocol.h',
+)
+
 protocol_sources += custom_target(
   'xdg-activation-protocol.c',
   command: [prog_scanner, output_type, '@INPUT@', '@OUTPUT@'],
-  input: protocol_file,
+  input: xdg_activation_file,
   output: 'xdg-activation-protocol.c',
+)
+
+# ext-background-effect-v1
+background_effect_file = files('ext-background-effect-v1.xml')
+
+protocol_sources += custom_target(
+  'ext-background-effect-v1-client-protocol.h',
+  command: [prog_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+  input: background_effect_file,
+  output: 'ext-background-effect-v1-client-protocol.h',
+)
+
+protocol_sources += custom_target(
+  'ext-background-effect-protocol.c',
+  command: [prog_scanner, output_type, '@INPUT@', '@OUTPUT@'],
+  input: background_effect_file,
+  output: 'ext-background-effect-protocol.c',
 )
 
 protocol_dep += declare_dependency(
   dependencies: [
     vala.find_library('xdg-activation-v1', dirs: meson.current_source_dir()),
+    vala.find_library('ext-background-effect-v1', dirs: meson.current_source_dir()),
     dependency('wayland-client'),
   ],
   include_directories: include_directories('.'),

--- a/src/background_effect.vala
+++ b/src/background_effect.vala
@@ -1,0 +1,314 @@
+/*
+ * Compositor-level background blur via ext-background-effect-v1 protocol.
+ *
+ * All Wayland proxy types (Wl.Registry, Manager, Wl.Compositor, Wl.Region)
+ * are [Compact] classes with a free_function — Vala auto-destroys owned
+ * instances when they go out of scope.  To avoid premature destruction we
+ * store proxies as raw void* and call wl_proxy_destroy() only from our
+ * explicit destructor.  Registry bindings use raw wl_registry_bind() rather
+ * than Vala's wl_registry.bind<T>() so no temporary compact wrapper is
+ * destroyed mid-callback.
+ *
+ * Config key: "background-blur" (bool, default false).
+ * Requires compositor support (tested on niri).
+ */
+using Ext.BackgroundEffect;
+
+[CCode (cname = "wl_compositor_interface", cheader_filename = "wayland-client-protocol.h")]
+private extern Wl.Interface compositor_interface;
+
+[CCode (cname = "wl_proxy_destroy", cheader_filename = "wayland-client.h")]
+private extern void wl_proxy_destroy (void *proxy);
+
+[CCode (cname = "wl_registry_bind", cheader_filename = "wayland-client.h")]
+private extern void *wl_registry_bind (void *registry, uint32 name,
+                                       ref Wl.Interface @interface,
+                                       uint32 version);
+
+[CCode (cname = "wl_registry_add_listener", cheader_filename = "wayland-client.h")]
+private extern int wl_registry_add_listener (void *registry,
+                                             Wl.RegistryListener listener,
+                                             void *data);
+
+[CCode (cname = "wl_region_destroy", cheader_filename = "wayland-client.h")]
+private extern void wl_region_destroy (void *region);
+
+[CCode (cname = "ext_background_effect_manager_v1_get_background_effect",
+        cheader_filename = "ext-background-effect-v1-client-protocol.h")]
+private extern Ext.BackgroundEffect.Surface *
+bg_manager_get_bg_effect (void *manager, Wl.Surface surface);
+
+[CCode (cname = "ext_background_effect_manager_v1_listener", has_type_id = false)]
+private struct BgManagerListener {
+    public BgManagerCapabilities capabilities;
+}
+
+[CCode (has_target = false, has_typedef = false)]
+private extern delegate void BgManagerCapabilities (void *data, void *manager, uint32 flags);
+
+[CCode (cname = "ext_background_effect_manager_v1_add_listener",
+        cheader_filename = "ext-background-effect-v1-client-protocol.h")]
+private extern int bg_manager_add_listener (void *manager,
+                                            BgManagerListener listener,
+                                            void *data);
+
+[CCode (cname = "ext_background_effect_surface_v1_destroy",
+        cheader_filename = "ext-background-effect-v1-client-protocol.h")]
+private extern void bg_surface_destroy (Ext.BackgroundEffect.Surface *effect);
+
+[CCode (cname = "ext_background_effect_surface_v1_set_blur_region",
+        cheader_filename = "ext-background-effect-v1-client-protocol.h")]
+private extern void bg_surface_set_blur_region (Ext.BackgroundEffect.Surface *effect, void *region);
+
+[CCode (cheader_filename = "gtk/gtk.h")]
+extern string gtk_style_context_to_string (Gtk.StyleContext ctx,
+                                           Gtk.StyleContextPrintFlags flags);
+
+[CCode (cname = "GTK_STYLE_CONTEXT_PRINT_SHOW_STYLE")]
+private const int GTK_STYLE_CONTEXT_PRINT_SHOW_STYLE = 1 << 1;
+
+namespace SwayNotificationCenter {
+    public class BackgroundEffectHelper : Object {
+        private const uint32 BG_CAPABILITY_BLUR = 1;
+
+        /* Raw proxy pointers — Vala never wraps/auto-destroys them. */
+        private void *manager_ptr = null;
+        private void *compositor_ptr = null;
+        private void *registry_ptr = null;
+
+        public bool blur_available { get; private set; default = false; }
+
+        public BackgroundEffectHelper () {
+            Gdk.Display ?display = Gdk.Display.get_default ();
+            if (display == null || !(display is Gdk.Wayland.Display)) {
+                warning ("Not running on Wayland — background blur disabled.");
+                return;
+            }
+
+            unowned Wl.Display wl_display =
+                ((Gdk.Wayland.Display) display).get_wl_display ();
+
+            registry_ptr = wl_display.get_registry ();
+            wl_registry_add_listener (registry_ptr,
+                                      build_registry_listener (), this);
+            wl_display.roundtrip ();
+
+            if (manager_ptr == null || compositor_ptr == null) {
+                warning (
+                    "ext-background-effect-v1 or wl_compositor not"
+                    + " available — background blur disabled.");
+                return;
+            }
+
+            if (!blur_available) {
+                warning (
+                    "ext-background-effect-v1 is available but blur is not"
+                    + " advertised by the compositor.");
+            }
+        }
+
+        ~BackgroundEffectHelper () {
+            /* All fields are void* — no Vala free_function auto-call.
+               Safe to destroy directly. */
+            if (manager_ptr != null) {
+                wl_proxy_destroy (manager_ptr);
+                manager_ptr = null;
+            }
+            if (compositor_ptr != null) {
+                wl_proxy_destroy (compositor_ptr);
+                compositor_ptr = null;
+            }
+            if (registry_ptr != null) {
+                wl_proxy_destroy (registry_ptr);
+                registry_ptr = null;
+            }
+        }
+
+        private Wl.RegistryListener build_registry_listener () {
+            return Wl.RegistryListener () {
+                       global = (data, wl_registry_void, name, iface, ver) => {
+                           var helper = (BackgroundEffectHelper) data;
+                           if (iface == "ext_background_effect_manager_v1") {
+                               void *bound = wl_registry_bind (
+                                   (void *) wl_registry_void,
+                                   name, ref Manager.iface, 1);
+                               helper.manager_ptr = bound;
+                               bg_manager_add_listener (
+                                   bound, build_manager_listener (), helper);
+                           } else if (iface == "wl_compositor") {
+                               uint32 bind_ver = ver >= 5 ? 5 : ver;
+                               void *bound = wl_registry_bind (
+                                   (void *) wl_registry_void,
+                                   name, ref compositor_interface, bind_ver);
+                               helper.compositor_ptr = bound;
+                           }
+                       },
+            };
+        }
+
+        private static BgManagerListener build_manager_listener () {
+            return BgManagerListener () {
+                       capabilities = handle_capabilities,
+            };
+        }
+
+        private static void handle_capabilities (void *data, void *manager,
+                                                 uint32 flags) {
+            var helper = (BackgroundEffectHelper) data;
+            helper.blur_available = (flags & BG_CAPABILITY_BLUR) != 0;
+        }
+
+        public Surface *create_effect (Wl.Surface wl_surface) {
+            if (!blur_available || manager_ptr == null
+                || wl_surface == null) {
+                return null;
+            }
+            return bg_manager_get_bg_effect (manager_ptr, wl_surface);
+        }
+
+        public void destroy_effect (Surface *effect) {
+            if (effect != null) {
+                bg_surface_destroy (effect);
+            }
+        }
+
+        public void set_blur_region (Surface *effect,
+                                     Cairo.Region ?cairo_region) {
+            if (effect == null || compositor_ptr == null) {
+                return;
+            }
+
+            if (cairo_region == null
+                || cairo_region.num_rectangles () == 0) {
+                bg_surface_set_blur_region (effect, null);
+                return;
+            }
+
+            int n = cairo_region.num_rectangles ();
+            void *region = wl_compositor_create_region (
+                compositor_ptr);
+            for (int i = 0; i < n; i++) {
+                Cairo.RectangleInt r =
+                    cairo_region.get_rectangle (i);
+                wl_region_add (region,
+                               r.x, r.y, r.width, r.height);
+            }
+            bg_surface_set_blur_region (effect, region);
+            wl_region_destroy (region);
+        }
+
+        public void set_blur_region_rounded (Surface *effect,
+                                             int x, int y,
+                                             int w, int h,
+                                             int radius) {
+            if (effect == null || compositor_ptr == null
+                || w <= 0 || h <= 0) {
+                return;
+            }
+
+            void *region = wl_compositor_create_region (
+                compositor_ptr);
+            add_rounded_card (region, x, y, w, h, radius);
+            bg_surface_set_blur_region (effect, region);
+            wl_region_destroy (region);
+        }
+
+        public void set_blur_region_multi_rounded (Surface *effect,
+                                                   int[] cards,
+                                                   int radius) {
+            if (effect == null || compositor_ptr == null
+                || cards.length < 4) {
+                return;
+            }
+
+            int n = cards.length / 4;
+            void *region = wl_compositor_create_region (
+                compositor_ptr);
+            for (int i = 0; i < n; i++) {
+                int off = i * 4;
+                add_rounded_card (region,
+                                  cards[off], cards[off + 1],
+                                  cards[off + 2], cards[off + 3],
+                                  radius);
+            }
+            bg_surface_set_blur_region (effect, region);
+            wl_region_destroy (region);
+        }
+
+        private static void add_rounded_card (void *region,
+                                              int x, int y,
+                                              int w, int h,
+                                              int radius) {
+            if (w <= 0 || h <= 0) {
+                return;
+            }
+            int r = int.min (radius, int.min (w / 2, h / 2));
+            if (r <= 0) {
+                wl_region_add (region, x, y, w, h);
+                return;
+            }
+            for (int row = 0; row < r; row++) {
+                int inset = (int) (r - Math.sqrt (
+                                       r * r - (r - row) * (r - row)));
+                int rw = w - 2 * inset;
+                if (rw <= 0) {
+                    continue;
+                }
+                wl_region_add (region,
+                               x + inset, y + row, rw, 1);
+                wl_region_add (region,
+                               x + inset, y + h - 1 - row,
+                               rw, 1);
+            }
+            int mid = h - 2 * r;
+            if (mid > 0) {
+                wl_region_add (region, x, y + r, w, mid);
+            }
+        }
+
+        public static int get_widget_border_radius (Gtk.Widget widget) {
+            if (widget == null) {
+                return 0;
+            }
+            Gtk.StyleContext ?ctx = widget.get_style_context ();
+            if (ctx == null) {
+                return 0;
+            }
+            string str = gtk_style_context_to_string (
+                ctx, (Gtk.StyleContextPrintFlags)
+                GTK_STYLE_CONTEXT_PRINT_SHOW_STYLE);
+            if (str == null || str.length == 0) {
+                return 0;
+            }
+            int idx = str.index_of ("--border-radius:");
+            if (idx < 0) {
+                return 0;
+            }
+            string val = str.substring (
+                idx + "--border-radius:".length).strip ();
+            int64 parsed = 0;
+            string digits = "";
+            for (int i = 0; i < val.length; i++) {
+                if (val[i].isdigit () || val[i] == '-') {
+                    digits += val[i].to_string ();
+                } else {
+                    break;
+                }
+            }
+            if (digits.length > 0
+                && int64.try_parse (digits, out parsed)) {
+                return (int) (parsed >= 0 ? parsed : 0);
+            }
+            return 0;
+        }
+
+        [CCode (cname = "wl_compositor_create_region",
+                cheader_filename = "wayland-client.h")]
+        private static extern void *wl_compositor_create_region (void *compositor);
+
+        [CCode (cname = "wl_region_add",
+                cheader_filename = "wayland-client.h")]
+        private static extern void wl_region_add (void *region, int32 x, int32 y,
+                                                  int32 width, int32 height);
+    }
+}

--- a/src/configModel/configModel.vala
+++ b/src/configModel/configModel.vala
@@ -553,6 +553,9 @@ namespace SwayNotificationCenter {
         /** Unsets the GTK_THEME env variable when true */
         public bool ignore_gtk_theme { get; set; default = true; }
 
+        /** Whether to use ext-background-effect-v1 for compositor blur */
+        public bool background_blur { get; set; default = false; }
+
         /** The notifications and controlcenters horizontal alignment */
         public PositionX positionX { // vala-lint=naming-convention
             get; set; default = PositionX.RIGHT;

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -13,6 +13,11 @@
       "description": "Unsets the GTK_THEME environment variable, fixing a lot of issues with GTK themes ruining the users custom CSS themes.",
       "default": true
     },
+    "background-blur": {
+      "type": "boolean",
+      "description": "Whether to use the ext-background-effect-v1 Wayland protocol for compositor-level background blur. Requires compositor support (e.g. niri). Set CSS background alpha < 1 on .control-center and .floating-notifications .notification for the blur to be visible.",
+      "default": false
+    },
     "positionX": {
       "type": "string",
       "description": "Horizontal position of control center and notification window",

--- a/src/controlCenter/controlCenter.vala
+++ b/src/controlCenter/controlCenter.vala
@@ -12,6 +12,13 @@ namespace SwayNotificationCenter {
 
         private Gtk.EventControllerKey key_controller;
 
+        private Ext.BackgroundEffect.Surface *bg_effect = null;
+        private int last_blur_x = -1;
+        private int last_blur_y = -1;
+        private int last_blur_w = -1;
+        private int last_blur_h = -1;
+        private int last_blur_radius = -1;
+
         /** Unsorted list of copies of all notifications */
         private List<unowned Widgets.BaseWidget> widgets;
         private const string[] DEFAULT_WIDGETS = { "title", "dnd", "notifications" };
@@ -52,11 +59,14 @@ namespace SwayNotificationCenter {
                     debug ("ControlCenter mapped on monitor: %s",
                            Functions.monitor_to_string (monitor));
                     app.show_blank_windows (monitor);
+
+                    update_blur_effect ();
                 });
             });
             this.unmap.connect (() => {
                 debug ("ControlCenter un-mapped");
                 app.hide_blank_windows ();
+                destroy_blur_effect ();
             });
 
             /*
@@ -131,7 +141,12 @@ namespace SwayNotificationCenter {
                     this.monitor_name = null;
                     set_anchor ();
                 }
+                update_blur_effect ();
             });
+        }
+
+        ~ControlCenter () {
+            destroy_blur_effect ();
         }
 
         private void key_released_event_cb (uint keyval, uint keycode, Gdk.ModifierType state) {
@@ -376,6 +391,8 @@ namespace SwayNotificationCenter {
             if (this.visible == visibility) {
                 return;
             }
+            destroy_blur_effect ();
+
             // Destroy the wl_surface to get a new "enter-monitor" signal and
             // fixes issues where keyboard shortcuts stop working after clearing
             // all notifications.
@@ -405,6 +422,91 @@ namespace SwayNotificationCenter {
                    Functions.monitor_to_string (monitor) ?? "Monitor Picked by Compositor");
             this.monitor_name = monitor == null ? null : monitor.connector;
             GtkLayerShell.set_monitor (this, monitor);
+        }
+
+        protected override void size_allocate (int w, int h, int baseline) {
+            base.size_allocate (w, h, baseline);
+            update_blur_effect ();
+        }
+
+        public void update_blur_effect () {
+            if (!ConfigModel.instance.background_blur
+                || !app.background_effect.blur_available) {
+                destroy_blur_effect ();
+                return;
+            }
+
+            unowned Gdk.Surface ?gdk_surface = get_surface ();
+            if (gdk_surface == null) {
+                return;
+            }
+            unowned Wl.Surface wlsurface = Functions.get_wl_surface (gdk_surface);
+            if (wlsurface == null) {
+                return;
+            }
+
+            if (bg_effect == null) {
+                bg_effect = app.background_effect.create_effect (wlsurface);
+                if (bg_effect == null) {
+                    return;
+                }
+            }
+
+            Graphene.Rect win_bounds;
+            if (!window.compute_bounds (this, out win_bounds)) {
+                return;
+            }
+
+            double surface_x, surface_y;
+            ((Gtk.Native) this).get_surface_transform (out surface_x, out surface_y);
+
+            int x = (int) win_bounds.get_x () + (int) surface_x;
+            int y = (int) win_bounds.get_y () + (int) surface_y;
+            int width = (int) win_bounds.get_width ();
+            int height = (int) win_bounds.get_height ();
+            if (width < 2 || height < 2) {
+                return;
+            }
+
+            int radius = BackgroundEffectHelper.get_widget_border_radius (window);
+
+            if (x == last_blur_x && y == last_blur_y
+                && width == last_blur_w && height == last_blur_h
+                && radius == last_blur_radius) {
+                return;
+            }
+            last_blur_x = x;
+            last_blur_y = y;
+            last_blur_w = width;
+            last_blur_h = height;
+            last_blur_radius = radius;
+
+            app.background_effect.set_blur_region_rounded (bg_effect, x, y,
+                                                           width, height, radius);
+            unowned Gdk.Surface ?s = get_surface ();
+            if (s != null) {
+                s.queue_render ();
+            }
+        }
+
+        private void destroy_blur_effect () {
+            if (bg_effect != null) {
+                app.background_effect.destroy_effect (bg_effect);
+                bg_effect = null;
+                queue_blur_commit ();
+            }
+            invalidate_blur_cache ();
+        }
+
+        private void queue_blur_commit () {
+            unowned Gdk.Surface ?surface = get_surface ();
+            if (surface != null) {
+                surface.queue_render ();
+            }
+        }
+
+        private inline void invalidate_blur_cache () {
+            last_blur_w = -1;
         }
     }
 }

--- a/src/main.vala
+++ b/src/main.vala
@@ -40,6 +40,8 @@ namespace SwayNotificationCenter {
 
         public XdgActivationHelper xdg_activation;
 
+        public BackgroundEffectHelper background_effect;
+
         public signal void config_reload (ConfigModel ?old_config, ConfigModel new_config);
 
         public Swaync (bool replace) {
@@ -143,6 +145,8 @@ namespace SwayNotificationCenter {
             yield;
 
             xdg_activation = new XdgActivationHelper ();
+
+            background_effect = new BackgroundEffectHelper ();
 
             floating_notifications = new NotificationWindow ();
             notifications_widget = new Widgets.Notifications ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -74,7 +74,9 @@ app_sources = [
   widget_sources,
   'blankWindow/blankWindow.vala',
   'functions.vala',
+  'background_effect.vala',
   'xdg_activation.vala',
+
   constants,
 ]
 

--- a/src/notification/notification.vala
+++ b/src/notification/notification.vala
@@ -812,6 +812,28 @@ namespace SwayNotificationCenter {
             });
         }
 
+        public bool get_blur_bounds (Gtk.Widget relative_to,
+                                     out int x, out int y,
+                                     out int w, out int h) {
+            x = 0;
+            y = 0;
+            w = 0;
+            h = 0;
+            Graphene.Rect bounds;
+            if (!base_box.compute_bounds (relative_to, out bounds)) {
+                return false;
+            }
+            x = (int) bounds.get_x ();
+            y = (int) bounds.get_y ();
+            w = (int) bounds.get_width ();
+            h = (int) bounds.get_height ();
+            return w > 0 && h > 0;
+        }
+
+        public int get_blur_radius () {
+            return BackgroundEffectHelper.get_widget_border_radius (base_box);
+        }
+
         public void remove_noti_timeout () {
             if (timeout_id > 0) {
                 Source.remove (timeout_id);

--- a/src/notificationWindow/notificationWindow.vala
+++ b/src/notificationWindow/notificationWindow.vala
@@ -12,6 +12,10 @@ namespace SwayNotificationCenter {
 
         private static string ?monitor_name = null;
 
+        private Ext.BackgroundEffect.Surface *bg_effect = null;
+        private int[] last_blur_cards = {};
+        private int last_blur_radius = -1;
+
         private const int MAX_HEIGHT = 600;
 
         public NotificationWindow () {
@@ -43,12 +47,15 @@ namespace SwayNotificationCenter {
                     debug ("NotificationWindow mapped on monitor: %s",
                            Functions.monitor_to_string (monitor));
 
+                    update_blur_effect ();
+
                     // Only set ON_DEMAND after the surface has been mapped
                     Idle.add_once (() => set_keyboard_mode ());
                 });
             });
             this.unmap.connect (() => {
                 set_keyboard_mode ();
+                destroy_blur_effect ();
                 debug ("NotificationWindow un-mapped");
             });
 
@@ -67,14 +74,18 @@ namespace SwayNotificationCenter {
                     NotificationWindow.monitor_name = null;
                     set_anchor ();
                 }
+                update_blur_effect ();
             });
+        }
+
+        ~NotificationWindow () {
+            destroy_blur_effect ();
         }
 
         protected override void size_allocate (int w, int h, int baseline) {
             base.size_allocate (w, h, baseline);
-
-            // Set the input region to only be the size of the ScrolledWindow
             set_input_region ();
+            update_blur_effect ();
         }
 
         protected override void snapshot (Gtk.Snapshot snapshot) {
@@ -105,6 +116,134 @@ namespace SwayNotificationCenter {
             }
         }
 
+        public void update_blur_effect () {
+            if (!ConfigModel.instance.background_blur
+                || !app.background_effect.blur_available) {
+                destroy_blur_effect ();
+                return;
+            }
+
+            unowned Gdk.Surface ?gdk_surface = get_surface ();
+            if (gdk_surface == null) {
+                return;
+            }
+            unowned Wl.Surface wlsurface = Functions.get_wl_surface (gdk_surface);
+            if (wlsurface == null) {
+                return;
+            }
+
+            if (bg_effect == null) {
+                bg_effect = app.background_effect.create_effect (wlsurface);
+                if (bg_effect == null) {
+                    return;
+                }
+            }
+
+            double surface_x, surface_y;
+            ((Gtk.Native) this).get_surface_transform (out surface_x, out surface_y);
+            int offset_x = (int) surface_x;
+            int offset_y = (int) surface_y;
+
+            int visible_count = 0;
+            foreach (unowned AnimatedListItem item in list.visible_children) {
+                if (item != null && !item.destroying && item.child != null) {
+                    visible_count++;
+                }
+            }
+
+            if (visible_count == 0) {
+                app.background_effect.set_blur_region (bg_effect, null);
+                last_blur_cards = {};
+                last_blur_radius = -1;
+                queue_blur_commit ();
+                return;
+            }
+
+            int[] cards = new int[visible_count * 4];
+            int card_idx = 0;
+            int radius = 0;
+            bool got_radius = false;
+
+            foreach (unowned AnimatedListItem item in list.visible_children) {
+                if (item == null || item.destroying) {
+                    continue;
+                }
+                unowned Notification noti = (Notification) item.child;
+                if (noti == null) {
+                    continue;
+                }
+
+                if (!got_radius) {
+                    radius = noti.get_blur_radius ();
+                    got_radius = true;
+                }
+
+                int bx, by, bw, bh;
+                if (!noti.get_blur_bounds (this, out bx, out by, out bw, out bh)) {
+                    continue;
+                }
+                int idx = card_idx * 4;
+                cards[idx] = bx + offset_x;
+                cards[idx + 1] = by + offset_y;
+                cards[idx + 2] = bw;
+                cards[idx + 3] = bh;
+                card_idx++;
+            }
+
+            if (card_idx == 0) {
+                app.background_effect.set_blur_region (bg_effect, null);
+                last_blur_cards = {};
+                last_blur_radius = -1;
+                queue_blur_commit ();
+                return;
+            }
+
+            if (card_idx * 4 < cards.length) {
+                cards.resize (card_idx * 4);
+            }
+
+            if (cards_equal (cards, last_blur_cards) && radius == last_blur_radius) {
+                return;
+            }
+            last_blur_cards = cards;
+            last_blur_radius = radius;
+
+            app.background_effect.set_blur_region_multi_rounded (bg_effect, cards, radius);
+            unowned Gdk.Surface ?s = get_surface ();
+            if (s != null) {
+                s.queue_render ();
+            }
+        }
+
+        private static bool cards_equal (int[] a, int[] b) {
+            if (a.length != b.length) {
+                return false;
+            }
+            for (int i = 0; i < a.length; i++) {
+                if (a[i] != b[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void destroy_blur_effect () {
+            if (bg_effect != null) {
+                app.background_effect.destroy_effect (bg_effect);
+                bg_effect = null;
+                queue_blur_commit ();
+            }
+            last_blur_cards = {};
+            last_blur_radius = -1;
+        }
+
+        private void queue_blur_commit () {
+            unowned Gdk.Surface ?surface = get_surface ();
+            if (surface != null) {
+                surface.queue_render ();
+            }
+        }
+
         private void set_anchor () {
             debug ("NotificationWindow set_anchor");
             if (app.use_layer_shell) {
@@ -113,19 +252,19 @@ namespace SwayNotificationCenter {
                 GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.BOTTOM, true);
                 GtkLayerShell.set_anchor (this, GtkLayerShell.Edge.TOP, true);
                 switch (ConfigModel.instance.positionX) {
-                    case PositionX.LEFT:
+                    case PositionX.LEFT :
                         GtkLayerShell.set_anchor (
                             this, GtkLayerShell.Edge.RIGHT, false);
                         GtkLayerShell.set_anchor (
                             this, GtkLayerShell.Edge.LEFT, true);
                         break;
-                    case PositionX.CENTER:
+                    case PositionX.CENTER :
                         GtkLayerShell.set_anchor (
                             this, GtkLayerShell.Edge.RIGHT, false);
                         GtkLayerShell.set_anchor (
                             this, GtkLayerShell.Edge.LEFT, false);
                         break;
-                    default:
+                        default :
                         GtkLayerShell.set_anchor (
                             this, GtkLayerShell.Edge.LEFT, false);
                         GtkLayerShell.set_anchor (
@@ -292,6 +431,7 @@ namespace SwayNotificationCenter {
                     return;
                 }
                 set_input_region ();
+                Idle.add_once (() => update_blur_effect ());
             });
         }
 
@@ -302,6 +442,7 @@ namespace SwayNotificationCenter {
                                                ConfigModel.instance.timeout_low,
                                                ConfigModel.instance.timeout_critical);
             if (!visible) {
+                destroy_blur_effect ();
                 // Destroy the wl_surface to get a new "enter-monitor" signal and
                 // fixes issues where keyboard shortcuts stop working after clearing
                 // all notifications.
@@ -320,6 +461,7 @@ namespace SwayNotificationCenter {
 
             list.append.begin (noti);
             notification_ids.set (param.applied_id, noti);
+            Idle.add_once (() => update_blur_effect ());
         }
 
         /** Removes the notification widget with ID. Doesn't dismiss */

--- a/src/swayncDaemon/swayncDaemon.vala
+++ b/src/swayncDaemon/swayncDaemon.vala
@@ -57,6 +57,10 @@ namespace SwayNotificationCenter {
         /** Reloads the CSS file */
         public bool reload_css () throws Error {
             bool result = Functions.load_css (style_path);
+            if (result) {
+                control_center.update_blur_effect ();
+                floating_notifications.update_blur_effect ();
+            }
             return result;
         }
 


### PR DESCRIPTION
- Add protocol XML + VAPI + scanner rules for ext-background-effect-v1
- Add BackgroundEffectHelper for registry binding, effect lifecycle, and rounded-rectangle region math
- Add "background-blur" config key (bool, default false)
- Wire blur into ControlCenter and NotificationWindow size allocations
- Add get_blur_bounds() / get_blur_radius() helpers to Notification

Assisted with LLM. Tested on Niri 26.04

Closes #705 