### PR TITLE
Fix Clear All button leaving phantom rows in control center in some cases

### DIFF
--- a/src/notificationGroup/notificationGroup.vala
+++ b/src/notificationGroup/notificationGroup.vala
@@ -222,7 +222,10 @@ namespace SwayNotificationCenter {
 
             if (get_mapped () && transition) {
                 remove_animation_done_id = remove_animation.done.connect ((e) => {
-                    play_remove_animation.callback ();
+                    Idle.add (() => {
+                        play_remove_animation.callback ();
+                        return Source.REMOVE;
+                    });
                 });
                 remove_animation.value_from
                     = remove_animation.state == Adw.AnimationState.PLAYING


### PR DESCRIPTION
play_remove_animation's done signal handler can fire synchronously during adw_animation_play(). Sometimes this means commit_group_removal is skipped and the listbox retains rows that have no visible children.

I tested it on two machines with very similar setups, but can only reliably reproduce it on one of them with the following:

- send some notifications using `notify-send 123` a few times
- click `Clear All` in the control center
- send another notification `notify-send 234` -> it will render below an "invisible gap"

This PR fixes that.