### PR TITLE
Fix loading Mpris album art from URLs without extensions

### DIFF
--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -305,7 +305,7 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                                                                     album_art_cancellable);
 
                         // Use PixbufLoader instead of from_stream_async to allow format auto-detection
-                        / Previously, it would use icon if the URL did not have the extension
+                        // Previously, it would use icon if the URL did not have the extension
                         Gdk.PixbufLoader loader = new Gdk.PixbufLoader ();
                         uint8[] buffer = new uint8[4096];
                         ssize_t bytes_read;

--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -299,30 +299,29 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                             album_art_texture = Gdk.Texture.for_pixbuf (pixbuf);
                         }
                     } else {
-                            // Load as a regular file/URL
-                            File file = File.new_for_uri (art_data);
-                            InputStream stream = yield file.read_async (Priority.DEFAULT,
-                                                                        album_art_cancellable);
+                        // Load as a regular file/URL
+                        File file = File.new_for_uri (art_data);
+                        InputStream stream = yield file.read_async (Priority.DEFAULT,
+                                                                    album_art_cancellable);
 
-                            // Use PixbufLoader instead of from_stream_async to allow format auto-detection
-                            // Previously, it would just fallback to the application icon if the URL did not specify the URL
-                            Gdk.PixbufLoader loader = new Gdk.PixbufLoader ();
-                            uint8[] buffer = new uint8[4096];
-                            ssize_t bytes_read;
-                            while ((bytes_read = yield stream.read_async (buffer, Priority.DEFAULT,
-                                                                        album_art_cancellable)) > 0) {
-                                loader.write (buffer[0:bytes_read]);
-                            }
-                            loader.close ();
-                            
-                            unowned Gdk.Pixbuf ?pixbuf = loader.get_pixbuf ();
-                            if (pixbuf != null) {
-                                album_art_texture = Gdk.Texture.for_pixbuf (pixbuf);
-                            }
-                    }
+                        // Use PixbufLoader instead of from_stream_async to allow format auto-detection
+                        / Previously, it would use icon if the URL did not have the extension
+                        Gdk.PixbufLoader loader = new Gdk.PixbufLoader ();
+                        uint8[] buffer = new uint8[4096];
+                        ssize_t bytes_read;
+                        while ((bytes_read = yield stream.read_async (buffer, Priority.DEFAULT,
+                                                                      album_art_cancellable)) > 0) {
+                            loader.write (buffer[0:bytes_read]);
+                        }
+                        loader.close ();
+
+                        unowned Gdk.Pixbuf ?pixbuf = loader.get_pixbuf ();
+                        if (pixbuf != null) {
+                            album_art_texture = Gdk.Texture.for_pixbuf (pixbuf);
+                        }
                 } catch (Error e) {
                     critical ("MPRIS (%s) album art error: %s. Using fallback...",
-                              source.media_player.identity, e.message);
+                             source.media_player.identity, e.message);
                 }
                 if (album_art_texture != null) {
                     // Set album art

--- a/src/controlCenter/widgets/mpris/mpris_player.vala
+++ b/src/controlCenter/widgets/mpris/mpris_player.vala
@@ -299,14 +299,26 @@ namespace SwayNotificationCenter.Widgets.Mpris {
                             album_art_texture = Gdk.Texture.for_pixbuf (pixbuf);
                         }
                     } else {
-                        // Load as a regular file/URL
-                        File file = File.new_for_uri (art_data);
-                        InputStream stream = yield file.read_async (Priority.DEFAULT,
-                                                                    album_art_cancellable);
+                            // Load as a regular file/URL
+                            File file = File.new_for_uri (art_data);
+                            InputStream stream = yield file.read_async (Priority.DEFAULT,
+                                                                        album_art_cancellable);
 
-                        Gdk.Pixbuf pixbuf = yield new Gdk.Pixbuf.from_stream_async (
-                            stream, album_art_cancellable);
-                        album_art_texture = Gdk.Texture.for_pixbuf (pixbuf);
+                            // Use PixbufLoader instead of from_stream_async to allow format auto-detection
+                            // Previously, it would just fallback to the application icon if the URL did not specify the URL
+                            Gdk.PixbufLoader loader = new Gdk.PixbufLoader ();
+                            uint8[] buffer = new uint8[4096];
+                            ssize_t bytes_read;
+                            while ((bytes_read = yield stream.read_async (buffer, Priority.DEFAULT,
+                                                                        album_art_cancellable)) > 0) {
+                                loader.write (buffer[0:bytes_read]);
+                            }
+                            loader.close ();
+                            
+                            unowned Gdk.Pixbuf ?pixbuf = loader.get_pixbuf ();
+                            if (pixbuf != null) {
+                                album_art_texture = Gdk.Texture.for_pixbuf (pixbuf);
+                            }
                     }
                 } catch (Error e) {
                     critical ("MPRIS (%s) album art error: %s. Using fallback...",


### PR DESCRIPTION
Spotify and other streaming services tended to not function, because they often don't include the file extension in the URL, and the previous implementation could not auto-detect it. Here, I've revamped the code for loading album art in order to resolve this issue.

<img width="468" height="191" alt="20260607_13h47m01s_grim" src="https://github.com/user-attachments/assets/e4294d66-b686-4a61-a56c-cba399ec2f70" />

It is worth noting that Spotify actually does not work by default. This is due to a well-known, long-standing bug in the Spotify desktop client where it references an older URL for it's album art. However, this fix still applies for Spotify in the browser, along with any other streaming services.